### PR TITLE
[PFTF-50] cookie 함수 수정

### DIFF
--- a/util/cookieSetting.ts
+++ b/util/cookieSetting.ts
@@ -1,16 +1,5 @@
 import { setCookie, destroyCookie } from "nookies";
 
-//쿠키를 가져오는 함수
-export function getCookie(name: string): string | undefined {
-  if (typeof window === "undefined") {
-    return undefined;
-  }
-
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(";").shift();
-}
-
 //accessToken을 쿠키로 저장하는 함수
 export function setAccessTokenCookie(accessTokenValue: string) {
   setCookie(null, "accessToken", accessTokenValue, {
@@ -18,6 +7,7 @@ export function setAccessTokenCookie(accessTokenValue: string) {
     path: "/",
     secure: true,
     sameSite: "strict",
+    httpOnly: true, //스크립트로 불러 올 수 없는 옵션 - xss공격 방지
   });
 }
 
@@ -28,16 +18,12 @@ export function setRefreshTokenCookie(refreshTokenValue: string) {
     path: "/",
     secure: true,
     sameSite: "strict",
+    httpOnly: true, //스크립트로 불러 올 수 없는 옵션 - xss공격 방지
   });
 }
 
 //생성한 모든 쿠키 삭제하는 코드(accessToken, refreshToken)
 export function removeAllTokenCookies() {
-  deleteCookie("accessToken");
-  deleteCookie("refreshToken");
-}
-
-//쿠키 삭제 함수
-export function deleteCookie(name: string) {
-  destroyCookie(null, name, { path: "/" });
+  destroyCookie(null, "accessToken", { path: "/" });
+  destroyCookie(null, "refreshToken", { path: "/" });
 }

--- a/util/cookieSetting.ts
+++ b/util/cookieSetting.ts
@@ -14,7 +14,7 @@ export function getCookie(name: string): string | undefined {
 //accessToken을 쿠키로 저장하는 함수
 export function setAccessTokenCookie(accessTokenValue: string) {
   setCookie(null, "accessToken", accessTokenValue, {
-    maxAge: 60 * 60, // 수명: 1시간
+    maxAge: 30 * 60, // 수명: 30분
     path: "/",
     secure: true,
     sameSite: "strict",
@@ -24,7 +24,7 @@ export function setAccessTokenCookie(accessTokenValue: string) {
 //refreshToken을 쿠키로 저장하는 함수
 export function setRefreshTokenCookie(refreshTokenValue: string) {
   setCookie(null, "refreshToken", refreshTokenValue, {
-    maxAge: 24 * 7 * 60 * 60, // 수명: 1주일
+    maxAge: 24 * 14 * 60 * 60, // 수명: 2주일
     path: "/",
     secure: true,
     sameSite: "strict",


### PR DESCRIPTION
## 🚀 작업 내용

- 토큰의 수명이 잘못되서 수정해야합니다. accessToken->30분, refreshToken->14일로 수정했습니다.
- httpOnly 속성을 넣어 xss공격을 방지하고 서버에서만 쿠키를 불러올 수 있도록 수정했습니다.
- 스크립트로 쿠키를 불러올 수 없으므로 getCookie함수는 불필요해 제거했습니다.

## 📝 참고 사항

- 더 이상 쿠키를 클라이언트에서 스크립트로 가져올 수 없습니다. 서버에서는 여전히 가져 올 수 있어 쿠키를 이용한 인증, 인가와 같은 로직은 middleware에서 처리할 예정입니다.


## 🖼️ 스크린샷

![image](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155133655/87c533a2-cb92-4018-9ae1-28d899950a60)

## 🚨 관련 이슈

-
