### PR TITLE
[PFTF-46] 공통 api 세팅

### DIFF
--- a/api.http
+++ b/api.http
@@ -1,11 +1,193 @@
+### 회원가입
+POST https://sp-globalnomad-api.vercel.app/4-14/users
+Content-Type: application/json
+
+{
+  "email": "test@naver.com",
+  "nickname": "테스트-네이버",
+  "password": "qwer1234"
+}
+
+### 로그인
+POST https://sp-globalnomad-api.vercel.app/4-14/auth/login
+Content-Type: application/json
+
+{
+  "email": "test@naver.com",
+  "password": "qwer1234"
+}
+
+### 내 정보 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/users/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+
+### 내 정보 수정
+PATCH https://sp-globalnomad-api.vercel.app/4-14/users/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "nickname": "테스트-naver",
+  "newPassword": "qwer1234"
+}
+
+### 프로필 이미지 url 생성
+POST https://sp-globalnomad-api.vercel.app/4-14/users/me/image
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "image": "",
+}
+
 ### 체험 리스트 조회(offset)
 GET https://sp-globalnomad-api.vercel.app/4-14/activities?method=offset
 
+### 체험 등록
+POST https://sp-globalnomad-api.vercel.app/4-14/activities?method=offset
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+Content-Type: application/json
+
+{
+  "title": "테스트용",
+  "category": "투어",
+  "description": "둠칫 둠칫 두둠칫",
+  "address": "서울특별시 강남구 테헤란로 427",
+  "price": 10000,
+  "schedules": [
+    {
+      "date": "2024-12-01",
+      "startTime": "12:00",
+      "endTime": "13:00"
+    },
+    {
+      "date": "2024-12-05",
+      "startTime": "12:00",
+      "endTime": "13:00"
+    },
+    {
+      "date": "2024-12-05",
+      "startTime": "13:00",
+      "endTime": "14:00"
+    },
+    {
+      "date": "2024-12-05",
+      "startTime": "14:00",
+      "endTime": "15:00"
+    }
+  ],
+  "bannerImageUrl": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/a.png",
+  "subImageUrls": [
+    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/b.png"
+  ]
+}
+
+### 체험 상세 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/activities/919
+
+### 체험 예약 가능일 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/activities/919/available-schedule?year=2024&month=12
+
+### 체험 리뷰 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/activities/916/reviews
+
+### 체험 예약 신청
+POST https://sp-globalnomad-api.vercel.app/4-14/activities/919/reservations
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "scheduleId": 3238,
+  "headCount": 5
+}
+
 ### 체험 이미지 url 생성
 POST https://sp-globalnomad-api.vercel.app/4-14/activities/images
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzA1LCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2Nzk3MzQxLCJleHAiOjE3MTY3OTkxNDEsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.am2_Hb_9yxoorVkJPGPbQAKtLRgfliHtUCiQJOqcDxc
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
 Content-Type: multipart/form-data
 
 {
-  "image" : ""
+  "image" : "asd"
+}
+
+### 토큰 재발급
+POST https://sp-globalnomad-api.vercel.app/4-14/auth/tokens
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MjUxLCJleHAiOjE3MTgwODQ4NTEsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.BEUy1gUXvHQt5AyK7EXchEVrHBZggoSdOax2i_S3oRk
+
+### 내 체험 리스트 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-activities
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+
+### 내 체험 월별 예약 현황 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-activities/919/reservation-dashboard?year=2024&month=12
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+
+### 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-activities/919/reserved-schedule?date=2024-12-01
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+
+### 내 체험 예약 시간대별 예약 내역 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-activities/919/reservations?scheduleId=3238&status=pending
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+
+### 내 체험 예약 상태(승인, 거절) 업데이트
+PATCH https://sp-globalnomad-api.vercel.app/4-14/my-activities/919/reservations/1398
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "status": "confirmed"
+}
+
+### 내 체험 삭제
+DELETE https://sp-globalnomad-api.vercel.app/4-14/my-activities/918
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+
+### 내 체험 수정
+PATCH https://sp-globalnomad-api.vercel.app/4-14/my-activities/916
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+Content-Type: application/json
+
+{
+  "title": "함께 해도 재미 없는 댄스",
+  "category": "문화 · 예술",
+  "description": "노잼요",
+  "price": 5000,
+  "address": "서울특별시 강남구 테헤란로 427",
+  "bannerImageUrl": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/a.png",
+  "subImageIdsToRemove": [],
+  "subImageUrlsToAdd": [],
+  "scheduleIdsToRemove": [],
+  "schedulesToAdd": []
+}
+
+### 내 알림 리스트 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-notifications
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+
+### 내 알림 삭제
+DELETE https://sp-globalnomad-api.vercel.app/4-14/my-notifications/874
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+
+### 내 예약 리스트 조회
+GET https://sp-globalnomad-api.vercel.app/4-14/my-reservations
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc1MDczLCJleHAiOjE3MTY4NzY4NzMsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.lpSqdApa73aop_52RfkHgVcdkS5FyNycFdrPB0VQVxI
+
+### 내 예약 수정 (취소)
+PATCH https://sp-globalnomad-api.vercel.app/4-14/my-reservations/1397
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "status" : "canceled"
+}
+
+### 내 예약 리뷰 작성
+POST https://sp-globalnomad-api.vercel.app/4-14/my-reservations/1398/reviews
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzIwLCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2ODc2OTE2LCJleHAiOjE3MTY4Nzg3MTYsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.Ob20fGj4lQQz6metvTmrx5W0UMGj_Ml-HKoQcvJUykY
+Content-Type: application/json
+
+{
+  "rating": 4,
+  "content": "생각보다 재밌네요~"
 }

--- a/api.http
+++ b/api.http
@@ -1,0 +1,11 @@
+### 체험 리스트 조회(offset)
+GET https://sp-globalnomad-api.vercel.app/4-14/activities?method=offset
+
+### 체험 이미지 url 생성
+POST https://sp-globalnomad-api.vercel.app/4-14/activities/images
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzA1LCJ0ZWFtSWQiOiI0LTE0IiwiaWF0IjoxNzE2Nzk3MzQxLCJleHAiOjE3MTY3OTkxNDEsImlzcyI6InNwLWdsb2JhbG5vbWFkIn0.am2_Hb_9yxoorVkJPGPbQAKtLRgfliHtUCiQJOqcDxc
+Content-Type: multipart/form-data
+
+{
+  "image" : ""
+}

--- a/util/api.ts
+++ b/util/api.ts
@@ -45,7 +45,7 @@ async function fetchWithToken(url: string, options: RequestInit = {}) {
     headers,
   };
 
-  let response = await fetch(url, mergedOptions);
+  const response = await fetch(url, mergedOptions);
 
   if (!response.ok) {
     const errorResponse = await response.json();
@@ -132,9 +132,9 @@ export function postLogin(body: LoginBody) {
   return fetcher(`/auth/login`, "POST", body);
 }
 
-// 토큰 재발급(현재 이상해서 질문 중)
-export function postTokens(body: ActivityImagesBody) {
-  return fetcher(`/auth/tokens`, "POST", body);
+// 토큰 재발급
+export function postTokens() {
+  return fetcher(`/auth/tokens`, "POST");
 }
 
 /** MyActivities

--- a/util/api.ts
+++ b/util/api.ts
@@ -124,17 +124,11 @@ export function postActivityImages(body: ActivityImagesBody) {
 
 /** Auth
  * 로그인
- * 토큰 재발급
  */
 
 // 로그인
 export function postLogin(body: LoginBody) {
   return fetcher(`/auth/login`, "POST", body);
-}
-
-// 토큰 재발급
-export function postTokens() {
-  return fetcher(`/auth/tokens`, "POST");
 }
 
 /** MyActivities

--- a/util/api.ts
+++ b/util/api.ts
@@ -1,0 +1,278 @@
+import {
+  ActivityImagesBody,
+  ActivityQuerys,
+  ActivityReservationBody,
+  ActivityReviewsQuery,
+  AvailableScheduleQuery,
+  FetchMethod,
+  LoginBody,
+  MyActivitiesQuery,
+  MyActivityBody,
+  MyNotificationsQuery,
+  MyReservationBody,
+  MyReservationReviewBody,
+  MyReservationsQuery,
+  PatchUserBody,
+  PostActivityBody,
+  PostUserBody,
+  ReservationBody,
+  ReservationDashBoardQuery,
+  ReservationsQuery,
+  ReservedScheduleQuery,
+  UserImageUrlBody,
+} from "./apiType";
+import { getCookie } from "./cookieSetting";
+import { convertQuery } from "./querySetting";
+
+// 기본 url
+const BASE_URL = "https://sp-globalnomad-api.vercel.app/4-14";
+
+// 토큰값도 함께 보내는 fetch함수
+async function fetchWithToken(url: string, options: RequestInit = {}) {
+  const headers = new Headers(options.headers as HeadersInit);
+  const accessToken = getCookie("accessToken");
+
+  if (accessToken) {
+    headers.append("Authorization", `Bearer ${accessToken}`);
+  }
+
+  if (!headers.has("Content-Type") && options.body) {
+    headers.append("Content-Type", "application/json");
+  }
+
+  const mergedOptions: RequestInit = {
+    ...options,
+    headers,
+  };
+
+  let response = await fetch(url, mergedOptions);
+
+  if (!response.ok) {
+    const errorResponse = await response.json();
+    console.error(errorResponse.message);
+    return;
+  }
+
+  return response.json();
+}
+
+async function fetcher(endpoint: string, method: FetchMethod, body?: Object) {
+  const options: RequestInit = {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+  };
+
+  return await fetchWithToken(`${BASE_URL}${endpoint}`, options);
+}
+
+/** Activities
+ * 체험 리스트 조회
+ * 체험 등록
+ * 체험 상세 조회
+ * 체험 예약 가능일 조회
+ * 체험 리뷰 조회
+ * 체험 예약 신청
+ * 체험 이미지 url 생성
+ */
+
+// 체험 리스트 조회
+export function getActivities(query: ActivityQuerys) {
+  const q = convertQuery(query);
+  return fetcher(`/activities${q}`, "GET");
+}
+
+// 체험 등록
+export function postActivity(body: PostActivityBody) {
+  return fetcher(`/activities`, "POST", body);
+}
+
+// 체험 상세 조회
+export function getActivityById(activityId: number) {
+  return fetcher(`/activities/${activityId}`, "GET");
+}
+
+// 체험 예약 가능일 조회
+export function getActivityAvailableSchedule(
+  activityId: number,
+  query: AvailableScheduleQuery,
+) {
+  const q = convertQuery(query);
+  return fetcher(`/activities/${activityId}/available-schedule${q}`, "GET");
+}
+
+// 체험 리뷰 조회
+export function getActivityReviews(
+  activityId: number,
+  query: ActivityReviewsQuery,
+) {
+  const q = convertQuery(query);
+  return fetcher(`/activities/${activityId}/reviews${q}`, "GET");
+}
+
+// 체험 예약 신청
+export function postActivityReservation(
+  activityId: number,
+  body: ActivityReservationBody,
+) {
+  return fetcher(`/activities/${activityId}/reservations`, "POST", body);
+}
+
+// 체험 이미지 url 생성
+export function postActivityImages(body: ActivityImagesBody) {
+  return fetcher(`/activities/image`, "POST", body);
+}
+
+/** Auth
+ * 로그인
+ * 토큰 재발급
+ */
+
+// 로그인
+export function postLogin(body: LoginBody) {
+  return fetcher(`/auth/login`, "POST", body);
+}
+
+// 토큰 재발급(현재 이상해서 질문 중)
+export function postTokens(body: ActivityImagesBody) {
+  return fetcher(`/auth/tokens`, "POST", body);
+}
+
+/** MyActivities
+ * 내 체험 리스트 조회
+ * 내 체험 월별 예약 현황 조회
+ * 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회
+ * 내 체험 예약 시간대별 예약 내역 조회
+ * 내 체험 예약 상태(승인, 거절) 업데이트
+ * 내 체험 삭제
+ * 내 체험 수정
+ */
+
+// 내 체험 리스트 조회
+export function getMyActivities(query: MyActivitiesQuery) {
+  const q = convertQuery(query);
+  return fetcher(`/my-activities${q}`, "GET");
+}
+
+// 내 체험 월별 예약 현황 조회
+export function getMyActivityReservationDashBoard(
+  activityId: number,
+  query: ReservationDashBoardQuery,
+) {
+  const q = convertQuery(query);
+  return fetcher(
+    `/my-activities/${activityId}/reservation-dashboard${q}`,
+    "GET",
+  );
+}
+
+// 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회
+export function getMyActivityReservedSchedule(
+  activityId: number,
+  query: ReservedScheduleQuery,
+) {
+  const q = convertQuery(query);
+  return fetcher(`/my-activities/${activityId}/reserved-schedule${q}`, "GET");
+}
+
+// 내 체험 예약 시간대별 예약 내역 조회
+export function getMyActivityReservations(
+  activityId: number,
+  query: ReservationsQuery,
+) {
+  const q = convertQuery(query);
+  return fetcher(`/my-activities/${activityId}/reservations${q}`, "GET");
+}
+
+// 내 체험 예약 상태(승인, 거절) 업데이트
+export function patchMyActivityReservation(
+  activityId: number,
+  reservationId: number,
+  body: ReservationBody,
+) {
+  return fetcher(
+    `/my-activities/${activityId}/reservations/${reservationId}`,
+    "PATCH",
+    body,
+  );
+}
+
+// 내 체험 삭제
+export function deleteMyActivity(activityId: number) {
+  return fetcher(`/my-activities/${activityId}`, "DELETE");
+}
+
+// 내 체험 수정
+export function patchMyActivity(activityId: number, body: MyActivityBody) {
+  return fetcher(`/my-activities/${activityId}`, "PATCH", body);
+}
+
+/** MyNotifications
+ * 내 알림 리스트 조회
+ * 내 알림 삭제
+ */
+
+// 내 알림 리스트 조회
+export function getMyNotifications(query: MyNotificationsQuery) {
+  const q = convertQuery(query);
+  return fetcher(`/my-notifications${q}`, "GET");
+}
+
+// 내 알림 삭제
+export function deleteMyNotification(notificationId: number) {
+  return fetcher(`/my-notifications/${notificationId}`, "DELETE");
+}
+
+/** MyReservations
+ * 내 예약 리스트 조회
+ * 내 예약 수정 (취소)
+ * 내 예약 리뷰 작성
+ */
+
+// 내 예약 리스트 조회
+export function getMyReservations(query: MyReservationsQuery) {
+  const q = convertQuery(query);
+  return fetcher(`/my-reservations${q}`, "GET");
+}
+
+// 내 예약 수정 (취소)
+export function patchMyReservation(
+  reservationId: number,
+  body: MyReservationBody,
+) {
+  return fetcher(`/my-reservations/${reservationId}`, "PATCH", body);
+}
+
+// 내 예약 리뷰 작성
+export function postMyReservationReview(
+  reservationId: number,
+  body: MyReservationReviewBody,
+) {
+  return fetcher(`/my-reservations/${reservationId}/reviews`, "POST", body);
+}
+
+/** Users
+ * 회원가입
+ * 내 정보 조회
+ * 내 정보 수정
+ * 프로필 이미지 url 작성
+ */
+
+// 회원가입
+export function postUser(body: PostUserBody) {
+  return fetcher(`/users`, "POST", body);
+}
+
+// 내 정보 조회
+export function getUser() {
+  return fetcher(`/users/me`, "GET");
+}
+
+// 내 정보 수정
+export function patchUser(body: PatchUserBody) {
+  return fetcher(`/users/me`, "PATCH", body);
+}
+
+// 프로필 이미지 url 작성
+export function postUserImageUrl(body: UserImageUrlBody) {
+  return fetcher(`/users/me/image`, "POST", body);
+}

--- a/util/api.ts
+++ b/util/api.ts
@@ -25,7 +25,7 @@ import { getCookie } from "./cookieSetting";
 import { convertQuery } from "./querySetting";
 
 // 기본 url
-const BASE_URL = "https://sp-globalnomad-api.vercel.app/4-14";
+export const BASE_URL = "https://sp-globalnomad-api.vercel.app/4-14";
 
 // 토큰값도 함께 보내는 fetch함수
 async function fetchWithToken(url: string, options: RequestInit = {}) {

--- a/util/apiType.ts
+++ b/util/apiType.ts
@@ -1,0 +1,161 @@
+// fetch 요청 타입
+export type FetchMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+// 정렬 쿼리 타입
+export type SortQuery = "most_reviewed" | "price_asc" | "price_desc" | "latest";
+
+// 카테고리 쿼리 타입
+export type CategoryQuery =
+  | "문화 · 예술"
+  | "식음료"
+  | "스포츠"
+  | "투어"
+  | "관광"
+  | "웰빙";
+
+// method 쿼리 타입
+export type MethodQuery = "offset" | "cursor";
+
+// 예약 상태 타입
+export type ReservationsStatus = "declined" | "pending" | "confirmed";
+
+// 스케줄 타입
+export interface Schedule {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+// 체험 리뷰 쿼리 타입
+export interface ActivityReviewsQuery {
+  [key: string]: number;
+  page: number;
+  size: number;
+}
+
+// 체험 예약 가능일 조회 쿼리 타입
+export interface AvailableScheduleQuery {
+  [key: string]: number;
+  year: number;
+  month: number;
+}
+
+// 내 체험 리스트 조회 쿼리 타입
+export interface MyActivitiesQuery {
+  [key: string]: number;
+  cursorId: number;
+  size: number;
+}
+
+// 내 체험 리스트 조회 쿼리 타입
+export interface ReservationDashBoardQuery extends AvailableScheduleQuery {}
+
+// 내 체험 리스트 조회 쿼리 타입
+export interface ReservedScheduleQuery {
+  [key: string]: string;
+  date: string;
+}
+
+// 내 체험 리스트 조회 쿼리 타입
+export interface ReservationsQuery {
+  [key: string]: string | undefined | number | ReservationsStatus;
+  cursorId?: string;
+  size?: string;
+  scheduleId: number;
+  status: ReservationsStatus;
+}
+
+// 내 알림 리스트 조회 쿼리 타입
+export interface MyNotificationsQuery extends MyActivitiesQuery {}
+
+// 내 예약 리스트 조회 쿼리 타입
+export interface MyReservationsQuery extends MyActivitiesQuery {}
+
+// 체험 등록 body 타입
+export interface PostActivityBody {
+  title: string; // required
+  category: string; // required
+  description: string; // required
+  address: string; // required
+  price: number; // required
+  schedules: Schedule[];
+  bannerImageUrl?: string;
+  subImageUrls?: string[];
+}
+
+// 회원가입 body 타입
+export interface ActivityQuerys {
+  [key: string]: number | string | MethodQuery | CategoryQuery | undefined;
+  method: MethodQuery; // required
+  cursorId?: number;
+  category?: CategoryQuery;
+  keyword?: string;
+  sort?: SortQuery;
+  page?: number; //default value: 1
+  size?: number; //default value: 20
+}
+
+// 체험 예약 신청 body 타입
+export interface ActivityReservationBody {
+  scheduleId: number;
+  headCount: number;
+}
+
+// 체험 이미지 url 생성 body 타입
+export interface ActivityImagesBody {
+  image: string;
+}
+
+// 프로필 이미지 url 생성 body 타입
+export interface UserImageUrlBody extends ActivityImagesBody {}
+
+// 회원가입 body 타입
+export interface PostUserBody {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+// 내 정보 수정 body 타입
+export interface PatchUserBody {
+  nickname: string;
+  profileImageUrl: string;
+  newPassword: string;
+}
+
+// 로그인 body 타입
+export interface LoginBody {
+  email: string;
+  password: string;
+}
+
+// 내 체험 예약 상태 body 타입
+export interface ReservationBody {
+  status: ReservationsStatus;
+}
+
+// 내 체험 수정 body 타입
+export interface MyActivityBody {
+  title: string; // required
+  category: string; // required
+  description: string; // required
+  address: string; // required
+  price: number; // required
+  schedules: Schedule[];
+  bannerImageUrl?: string;
+  subImageIdsToRemove: number[];
+  subImageUrlsToAdd: string[];
+  scheduleIdsToRemove: number[];
+  schedulesToAdd: Schedule[];
+}
+
+// 내 예약 수정 (취소) body 타입
+export interface MyReservationBody {
+  status: "canceled";
+}
+
+// 내 예약 리뷰 작성 body 타입
+export interface MyReservationReviewBody {
+  rating: number;
+  content: string;
+}

--- a/util/apiType.ts
+++ b/util/apiType.ts
@@ -47,16 +47,16 @@ export interface MyActivitiesQuery {
   size: number;
 }
 
-// 내 체험 리스트 조회 쿼리 타입
+// 내 체험 월별 예약 현황 조회 쿼리 타입
 export interface ReservationDashBoardQuery extends AvailableScheduleQuery {}
 
-// 내 체험 리스트 조회 쿼리 타입
+// 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회 쿼리 타입
 export interface ReservedScheduleQuery {
   [key: string]: string;
   date: string;
 }
 
-// 내 체험 리스트 조회 쿼리 타입
+// 내 체험 예약 시간대별 예약 내역 조회 쿼리 타입
 export interface ReservationsQuery {
   [key: string]: string | undefined | number | ReservationsStatus;
   cursorId?: string;

--- a/util/querySetting.ts
+++ b/util/querySetting.ts
@@ -1,0 +1,26 @@
+interface QueryObject<T> {
+  [key: string]: T | T[] | undefined;
+}
+
+export function convertQuery<T>(query: QueryObject<T>): string {
+  let convertedQuery = "";
+  if (query) {
+    const queryParams = new URLSearchParams();
+    for (const key in query) {
+      const value = query[key];
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          queryParams.append(key, item as string);
+        });
+      } else if (value !== undefined) {
+        queryParams.append(key, query[key]!.toString());
+      }
+    }
+
+    const queryString = queryParams.toString();
+    if (queryString) {
+      convertedQuery += `?${queryString}`;
+    }
+  }
+  return convertedQuery;
+}


### PR DESCRIPTION
## 🚀 작업 내용

- 공통 fetcher함수를 작성했습니다.
- api.http 파일을 작성하여 쉽게 테스트 할 수 있게 했습니다.
- api.ts 파일을 작성하여 모든 api 호출에 대해 대응할 수 있도록 했습니다.
- 쿼리 값을 객체로 받고 해당 객체를 api 요청 시 뒤에 붙이는 쿼리 string으로 변환하는 함수를 만들었습니다.
- 각종 api 요청에 필요한 쿼리나 body 값에 대한 type을 작성하였습니다.

## 📝 참고 사항

- 프로필 이미지 및 체험 이미지 url 생성 api는 binary 값을 요구해 테스트 하지 못했습니다.
- 알맞은 api 함수에 쿼리 객체나 body 객체를 보내면 api 요청이 됩니다.
- endpoint를 모두 지정해 둬서 따로 지정 할 필요 없습니다.
- api.http를 통해 모두 테스트 했습니다.(이미지 제외)

## 🖼️ 스크린샷

![image](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155133655/d918f4f3-1c90-45a5-b916-970fe1a93165)


## 🚨 관련 이슈

- 아직 없습니다.
