### PR TITLE
[PFTF-23] 버튼 컴포넌트 작업 완료

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -11,7 +11,7 @@ export const ButtonVariants = cva(
     //variant , size에 따라 다른 디자인을 보여줄수 있다
     variants: {
       variant: {
-        primary: "bg-nomad-black text-white ",
+        primary: " bg-nomad-black text-white ",
         white: " bg-white text-nomad-black border-nomad-black border-[1px] ",
         gray: " bg-gray-60 cursor-not-allowed text-white ",
       },

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -43,6 +43,7 @@ interface ButtonProps
  * @children ReactElement 아이콘같은걸 넣어준다
  * @additionalClass 추가할 클래스 속성을 넣어준다
  * @props 추가할 버튼 속성을 넣어준다
+ * @type 현재 버튼의 타입을 넣어준다. 기본값은 button
  */
 const Button: FC<ButtonProps> = ({
   variant,
@@ -50,6 +51,7 @@ const Button: FC<ButtonProps> = ({
   children,
   additionalClass,
   disabled,
+  type = "button",
   ...props
 }) => {
   return (
@@ -59,6 +61,7 @@ const Button: FC<ButtonProps> = ({
         additionalClass,
       )}
       disabled={disabled}
+      type={type}
       {...props}
     >
       {children && children}

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -11,9 +11,9 @@ export const ButtonVariants = cva(
     //variant , size에 따라 다른 디자인을 보여줄수 있다
     variants: {
       variant: {
-        primary: "bg-[#112211] text-white ",
-        white: " bg-white text-[#112211] border-[#112211] border-[1px] ",
-        gray: " bg-[#A4A1AA] cursor-not-allowed text-white ",
+        primary: "bg-nomad-black text-white ",
+        white: " bg-white text-nomad-black border-nomad-black border-[1px] ",
+        gray: " bg-gray-60 cursor-not-allowed text-white ",
       },
       size: {
         full: "w-full py-[14px] h-48px] text-base font-bold leading-[125%] ",

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,22 +1,69 @@
-import React from "react";
+import { tailwindClassMerge } from "@/util/tailwindClassMerge";
+import { cva, VariantProps } from "class-variance-authority";
+import { ButtonHTMLAttributes, FC, ReactNode } from "react";
 
-interface ButtonTypes {
-  name: string;
-  size: string;
-  color: "default" | "white" | "gray";
-  type: "button" | "submit";
-  onClick: () => void;
-  class?: string;
+export const ButtonVariants = cva(
+  //모든 경우에 공통으로 들어갈 CSS
+  `
+  flex justify-center items-center rounded-md 
+  `,
+  {
+    //variant , size에 따라 다른 디자인을 보여줄수 있다
+    variants: {
+      variant: {
+        primary: "bg-[#112211] text-white ",
+        white: " bg-white text-[#112211] border-[#112211] border-[1px] ",
+        gray: " bg-[#A4A1AA] cursor-not-allowed text-white ",
+      },
+      size: {
+        full: "w-full py-[14px] h-48px] text-base font-bold leading-[125%] ",
+        lg: "w-[350px] py-[14px] h-[48px] text-base font-bold leading-[125%] ",
+        md: "w-[144px] py-[8px] h-[48px] text-base font-bold leading-[100%] ",
+        sm: "w-[108px] py-[10px] h-[38px] text-sm font-bold ",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "full",
+    },
+  },
+);
+
+interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    //Button의 속성을 타입지정을 통해 손쉽게 사용
+    VariantProps<typeof ButtonVariants> {
+  children?: ReactNode;
+  additionalClass?: string;
 }
 
-const Button = ({
-  name,
+/**
+ * @variant 색상 지정 ex) gray, blue, red
+ * @size 사이즈 지정 md, lg, wlg
+ * @children ReactElement 아이콘같은걸 넣어준다
+ * @additionalClass 추가할 클래스 속성을 넣어준다
+ * @props 추가할 버튼 속성을 넣어준다
+ */
+const Button: FC<ButtonProps> = ({
+  variant,
   size,
-  color = "default",
-  onClick,
-  type = "button",
-}: ButtonTypes) => {
-  return <button></button>;
+  children,
+  additionalClass,
+  disabled,
+  ...props
+}) => {
+  return (
+    <button
+      className={tailwindClassMerge(
+        ButtonVariants({ variant: disabled ? "gray" : variant, size }),
+        additionalClass,
+      )}
+      disabled={disabled}
+      {...props}
+    >
+      {children && children}
+    </button>
+  );
 };
 
 export default Button;

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface ButtonTypes {
+  name: string;
+  size: string;
+  color: "default" | "white" | "gray";
+  type: "button" | "submit";
+  onClick: () => void;
+  class?: string;
+}
+
+const Button = ({
+  name,
+  size,
+  color = "default",
+  onClick,
+  type = "button",
+}: ButtonTypes) => {
+  return <button></button>;
+};
+
+export default Button;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
         "next": "14.2.3",
         "nookies": "^2.5.2",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "tailwind-merge": "^2.3.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -43,7 +46,6 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
       "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1168,11 +1170,38 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4171,7 +4200,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -4753,6 +4781,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.3.0.tgz",
+      "integrity": "sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "next": "14.2.3",
     "nookies": "^2.5.2",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/util/tailwindClassMerge.ts
+++ b/util/tailwindClassMerge.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export const tailwindClassMerge = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs));
+};


### PR DESCRIPTION
## 🚀 작업 내용

- #23 내용 기반으로 버튼 컴포넌트 작업
- size prop으로 size를 받을 수 있게 설계
- variant prop으로 bg-color를 받을 수 있게 설계
- children으로 버튼명 받을 수 있게 설계
- ...prop으로 onClick을 받을 수 있게 설계
- additionnalClass prop으로 추가적인 class를 받을 수 있게 설계

- 추가적으로 type(submit, button. 기본값은 button)을 받을 수 있게 함
- 추가적으로 disabled를 넣을 경우 자동적으로 variant를 gray로 설정하도록 함.

## 📝 참고 사항

- cva, clsx, tailwindMerge lib를 추가하여, npm i 를 실행하셔야 관련 기능이 제대로 작동할 겁니다.

## 🖼️ 스크린샷

### 기본값입니다. full size로 적용되어있습니다.
<img width="1106" alt="스크린샷 2024-05-28 오후 5 45 45" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/871e97f6-949b-44a5-b7b2-cb9dba81c18a">

### large를 적용한 모습입니다. 버튼 내부 내용은 children을 받아서 보여줍니다.
<img width="407" alt="스크린샷 2024-05-28 오후 5 46 02" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/66b75d37-d91c-40e6-929a-3de1e44caaa3">

### disabled 속성을 적용하면 자동적으로 gray속성을 적용합니다.
<img width="282" alt="스크린샷 2024-05-28 오후 5 48 19" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/49dc59e9-7d5a-4973-afb2-a2c744fbf29a">
<img width="403" alt="스크린샷 2024-05-28 오후 5 48 26" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/b01da7d2-55d8-4cef-8af6-0d4a507abc4f">

## 🚨 관련 이슈
- #23 
