### PR TITLE
[PFTF-60] 쿠키 로직 변경에 따른 api 함수 수정

### DIFF
--- a/app/(app)/activity-management/page.tsx
+++ b/app/(app)/activity-management/page.tsx
@@ -1,10 +1,33 @@
+"use client";
+import ApiTest1 from "@/components/test/ApiTest1";
+import ApiTest2 from "@/components/test/ApiTest2";
 import ColorTest from "@/components/test/ColorTest";
+import { logout, postLogin } from "@/util/api";
+import type { LoginBody } from "@/util/apiType";
+
 import React from "react";
 
 type Props = {};
 
 const page = (props: Props) => {
-  return <ColorTest></ColorTest>;
+  const loginTest = async () => {
+    const body: LoginBody = {
+      email: "test@naver.com",
+      password: "qwer1234",
+    };
+    const res = await postLogin(body);
+    console.log(res);
+  };
+
+  return (
+    <>
+      <ColorTest />
+      <div onClick={loginTest}>로그인</div>
+      <div onClick={logout}>로그아웃</div>
+      <ApiTest1>apiGETFunctionTest</ApiTest1>
+      <ApiTest2>apiGETFunctionTest</ApiTest2>
+    </>
+  );
 };
 
 export default page;

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
-export const pretendard = localFont({
+const pretendard = localFont({
   src: "../../public/fonts/PretendardVariable.woff2",
   display: "swap",
   weight: "45 920",

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,14 @@
 import type { Metadata } from "next";
 import "../(app)/globals.css";
-import { pretendard } from "../(app)/layout";
+import localFont from "next/font/local";
+
+const pretendard = localFont({
+  src: "../../public/fonts/PretendardVariable.woff2",
+  display: "swap",
+  weight: "45 920",
+  variable: "--font-pretendard",
+});
+
 export const metadata: Metadata = {
   title: "GlobalNomad",
   description: "여행",

--- a/app/api/fetchWithToken/route.ts
+++ b/app/api/fetchWithToken/route.ts
@@ -1,0 +1,71 @@
+import { BASE_URL } from "@/util/api";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+async function handleRequest(request: NextRequest) {
+  // 클라이언트가 보낸 JSON 데이터를 파싱
+  const { endpoint, body, method } = await request.json();
+
+  // 서버 측에서 httpOnly 쿠키 읽기
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  // 요청에 필요한 헤더 설정
+  const headers = new Headers();
+  if (accessToken) {
+    headers.append("Authorization", `Bearer ${accessToken}`);
+  }
+
+  if (body) {
+    headers.append("Content-Type", "application/json");
+  }
+
+  const options: RequestInit = {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : null,
+  };
+
+  try {
+    // 원격 서버로 요청을 전송
+    const response = await fetch(`${BASE_URL}${endpoint}`, options);
+
+    if (!response.ok) {
+      const errorResponse = await response.json();
+      return NextResponse.json(
+        { message: errorResponse.message },
+        { status: response.status },
+      );
+    }
+    // 응답 데이터를 JSON 형식으로 반환
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { message: "내부 서버 오류가 발생했습니다." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function PATCH(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  return handleRequest(request);
+}

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,51 @@
+import { BASE_URL } from "@/util/api";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import {
+  setAccessTokenCookie,
+  setRefreshTokenCookie,
+} from "@/util/cookieSetting";
+
+async function handleRequest(request: NextRequest) {
+  // 클라이언트가 보낸 JSON 데이터를 파싱
+  const { endpoint, body, method } = await request.json();
+
+  const options: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : null,
+  };
+
+  try {
+    // 원격 서버로 요청을 전송
+    const response = await fetch(`${BASE_URL}${endpoint}`, options);
+
+    if (!response.ok) {
+      const errorResponse = await response.json();
+      return NextResponse.json(
+        { message: errorResponse.message },
+        { status: response.status },
+      );
+    }
+
+    // 응답 데이터를 JSON 형식으로 반환
+    const data = await response.json();
+
+    //accessToken과 refreshToken 쿠키 설정
+    setAccessTokenCookie(data.accessToken);
+    setRefreshTokenCookie(data.refreshToken);
+
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { message: "내부 서버 오류가 발생했습니다." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request);
+}

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,11 @@
+import { removeAllTokenCookies } from "@/util/cookieSetting";
+import { NextResponse } from "next/server";
+
+export async function handleRequest() {
+  removeAllTokenCookies();
+  return NextResponse.json({ message: "로그아웃되었습니다." }, { status: 200 });
+}
+
+export async function POST() {
+  return handleRequest();
+}

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,11 +1,13 @@
 import { removeAllTokenCookies } from "@/util/cookieSetting";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function handleRequest() {
+async function handleRequest(
+  request: NextRequest,
+): Promise<NextResponse<{ message: string }>> {
   removeAllTokenCookies();
   return NextResponse.json({ message: "로그아웃되었습니다." }, { status: 200 });
 }
 
-export async function POST() {
-  return handleRequest();
+export async function POST(request: NextRequest) {
+  return handleRequest(request);
 }

--- a/components/test/ApiTest1.tsx
+++ b/components/test/ApiTest1.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { getActivities } from "@/util/api";
+import { ActivityQuerys } from "@/util/apiType";
+import React from "react";
+
+const ApiTest1 = ({ children }: { children: React.ReactNode }) => {
+  const apiGETFunctionTest = async () => {
+    const query: ActivityQuerys = {
+      method: "offset",
+    };
+    const res = await getActivities(query);
+    console.log(res);
+  };
+  return <div onClick={apiGETFunctionTest}>{children}</div>;
+};
+
+export default ApiTest1;

--- a/components/test/ApiTest2.tsx
+++ b/components/test/ApiTest2.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { postActivity } from "@/util/api";
+import { PostActivityBody } from "@/util/apiType";
+import React from "react";
+
+const ApiTest2 = ({ children }: { children: React.ReactNode }) => {
+  const apiPOSTFunctionTest = async () => {
+    const body: PostActivityBody = {
+      title: "테스트용123",
+      category: "투어",
+      description: "둠칫 둠칫 두둠칫",
+      address: "서울특별시 강남구 테헤란로 427",
+      price: 10000,
+      schedules: [
+        {
+          date: "2024-12-01",
+          startTime: "12:00",
+          endTime: "13:00",
+        },
+        {
+          date: "2024-12-05",
+          startTime: "12:00",
+          endTime: "13:00",
+        },
+        {
+          date: "2024-12-05",
+          startTime: "13:00",
+          endTime: "14:00",
+        },
+        {
+          date: "2024-12-05",
+          startTime: "14:00",
+          endTime: "15:00",
+        },
+      ],
+      bannerImageUrl:
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/a.png",
+      subImageUrls: [
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/b.png",
+      ],
+    };
+    const res = await postActivity(body);
+    console.log(res);
+  };
+  return <div onClick={apiPOSTFunctionTest}>{children}</div>;
+};
+
+export default ApiTest2;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "next": "14.2.3",
-        "nookies": "^2.5.2",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0"
@@ -1239,15 +1238,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3470,16 +3460,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/nookies": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
-      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^0.4.1",
-        "set-cookie-parser": "^2.4.6"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4389,12 +4369,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "next": "14.2.3",
-    "nookies": "^2.5.2",
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.3.0"

--- a/util/cookieSetting.ts
+++ b/util/cookieSetting.ts
@@ -1,19 +1,21 @@
-import { setCookie, destroyCookie } from "nookies";
+import { cookies } from "next/headers";
 
 //accessToken을 쿠키로 저장하는 함수
 export function setAccessTokenCookie(accessTokenValue: string) {
-  setCookie(null, "accessToken", accessTokenValue, {
+  const cookieStore = cookies();
+  cookieStore.set("accessToken", accessTokenValue, {
     maxAge: 30 * 60, // 수명: 30분
     path: "/",
     secure: true,
     sameSite: "strict",
-    httpOnly: true, //스크립트로 불러 올 수 없는 옵션 - xss공격 방지
+    httpOnly: true, //스크립트로 불러 올 수 없는 옵션 - xss공격 방지})
   });
 }
 
 //refreshToken을 쿠키로 저장하는 함수
 export function setRefreshTokenCookie(refreshTokenValue: string) {
-  setCookie(null, "refreshToken", refreshTokenValue, {
+  const cookieStore = cookies();
+  cookieStore.set("refreshToken", refreshTokenValue, {
     maxAge: 24 * 14 * 60 * 60, // 수명: 2주일
     path: "/",
     secure: true,
@@ -24,6 +26,7 @@ export function setRefreshTokenCookie(refreshTokenValue: string) {
 
 //생성한 모든 쿠키 삭제하는 코드(accessToken, refreshToken)
 export function removeAllTokenCookies() {
-  destroyCookie(null, "accessToken", { path: "/" });
-  destroyCookie(null, "refreshToken", { path: "/" });
+  const cookieStore = cookies();
+  cookieStore.delete("accessToken");
+  cookieStore.delete("refreshToken");
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 쿠키를 nookie 라이브러리 없이 설정하는 함수로 변경
- 불필요한 라이브러리 제거(nookies)
- 로그인, 로그아웃 테스트 성공
- route.ts파일 작성해 서버에서 쿠키 저장 및 삭제할 수 있도록 설정
- 변경된 쿠키 세팅으로 인해 수정
- router에러 제거를 위해 export제거
- layout 에러 제거 위해 수정


## 📝 참고 사항

- 기존에는 공통 fetcher함수(fetchWithToken)에서 쿠키를 클라이언트단에서 get 하는 로직으로 만들었으나 httpOnly:true로 인해 클라이언트에서 하지 못하여 서버에서 할 수 있도록 코드를 작성하게 되었습니다.
- 이로 인해 다양한 파일과 api 관련 코드가 수정이 되어야 해서 해당 이슈에 대응하여 pr 올립니다.
- 현재 deploy에러가 발생하고 있어 이를 제거하였습니다.

## 🖼️ 스크린샷

https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155133655/dc454172-53c8-4a15-86ea-2c29cedb1d87


## 🚨 관련 이슈

- #46 
- #50 
- #60 
