### PR TITLE
[PFTF-20] pagination 컴포넌트 작업

### DIFF
--- a/components/common/Pagination/PaginationArrow.tsx
+++ b/components/common/Pagination/PaginationArrow.tsx
@@ -27,8 +27,8 @@ const PaginationArrow = ({
           id="Vector 668"
           d="M16 11L26.2929 21.2929C26.6834 21.6834 26.6834 22.3166 26.2929 22.7071L16 33"
           stroke={color}
-          stroke-width="3"
-          stroke-linecap="round"
+          strokeWidth="3"
+          strokeLinecap="round"
         />
       </g>
     </svg>

--- a/components/common/Pagination/PaginationArrow.tsx
+++ b/components/common/Pagination/PaginationArrow.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface PaginationArrow {
+  width?: number;
+  height?: number;
+  color?: string;
+  className?: string;
+}
+
+const PaginationArrow = ({
+  width = 40,
+  height = 40,
+  color = "#4B4B4B",
+  className = "",
+}: PaginationArrow) => {
+  return (
+    <svg
+      className={className}
+      width={`${width}`}
+      height={`${height}`}
+      viewBox="0 0 44 44"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Property 1=Variant4">
+        <path
+          id="Vector 668"
+          d="M16 11L26.2929 21.2929C26.6834 21.6834 26.6834 22.3166 26.2929 22.7071L16 33"
+          stroke={color}
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default PaginationArrow;

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -1,22 +1,20 @@
 "use client";
 
-import React, { SetStateAction, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import PaginationArrow from "./PaginationArrow";
 
 interface PaginationProps {
   count: number;
-  onPageClick: (currentPageData: number) => void;
+  onPageClick: (currentPageNum: number) => void;
   pageItemLimit?: number;
   pageRefreshSwitch?: boolean;
-  enableAnchorNavigation?: boolean;
-  setIsFilterChanged?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 /**
  * @param {number} count 현재 페이지네이션할 데이터의 총량을 받습니다.
  * @param {number} pageItemLimit 현재 페이지에 얼마나 많은 개수를 표기할 지 선택하는 인수입니다. 기본적으로 리뷰 컴포넌트에서 표시하는 3값으로 설정되어있습니다.
  * @param {function} onPageClick 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다.
- * @param {boolean} pageRefreshSwitch 현재 페이지가 변화하여 1페이지로 돌아가야 함을 알려줄 때 사용합니다. setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
+ * @param {boolean} pageRefreshSwitch 현재 페이지가 변화하여 1페이지로 돌아가야 함을 알려줄 때 사용합니다. ex)filter적용 setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
  * @returns
  */
 const Pagination = ({
@@ -85,7 +83,7 @@ const Pagination = ({
   }, [pageRefreshSwitch]);
 
   return (
-    <div className="flex h-16 w-full items-center justify-center gap-2 bg-white p-3 ">
+    <div className="flex h-10 w-full items-center justify-center gap-2 bg-white p-3 md:h-14 ">
       <button
         type="button"
         className={`h-5 w-5 rounded-full 
@@ -95,12 +93,12 @@ const Pagination = ({
         <PaginationArrow className="h-full w-full rotate-180" />
       </button>
 
-      <div className="flex min-w-80 justify-center gap-2.5">
+      <div className="flex min-w-60 justify-center gap-2.5 md:min-w-80">
         {currentPageList.map((item) => (
           <React.Fragment key={`pagination-${item}`}>
             <button
               type="button"
-              className={`h-14 w-14 rounded-2xl border border-black
+              className={`h-10 w-10 rounded-2xl border border-black md:h-14 md:w-14
             ${currentPage === item ? "bg-nomad-black text-white" : "text-black hover:bg-gray-10"}`}
               onClick={() => handlePageNumberChange(item)}
             >

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import PaginationArrow from "./PaginationArrow";
+import Arrow from "../svg/Arrow";
 
 interface PaginationProps {
   count: number;
@@ -90,7 +90,7 @@ const Pagination = ({
           ${currentPage !== 1 ? "hover:bg-gray-20" : "cursor-default opacity-40"}`}
         onClick={() => handlePaginationArrowButton(false)}
       >
-        <PaginationArrow className="h-full w-full rotate-180" />
+        <Arrow className="h-full w-full rotate-180" />
       </button>
 
       <div className="flex min-w-60 justify-center gap-2.5 md:min-w-80">
@@ -114,7 +114,7 @@ const Pagination = ({
           ${currentPage < lastPageNum ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
         onClick={() => handlePaginationArrowButton(true)}
       >
-        <PaginationArrow className="h-full w-full" />
+        <Arrow className="h-full w-full" />
       </button>
     </div>
   );

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -35,7 +35,7 @@ const Pagination = ({
   const handlePageNumberChange = (pageNum: number) => {
     setCurrentPage(pageNum);
     onPageClick(pageNum);
-    if (pageNum % 5 === 1) {
+    if (pageNum % 5 === 1 && pageNum < lastPageNum) {
       const pageList = [];
       for (let i = pageNum; i <= pageNum + 4 && i <= lastPageNum; i++) {
         pageList.push(i);
@@ -43,7 +43,7 @@ const Pagination = ({
       setCurrentPageList(pageList);
     }
 
-    if (pageNum % 5 === 0) {
+    if (pageNum % 5 === 0 && pageNum < lastPageNum) {
       const pageList = [];
       for (let i = pageNum - 4; i <= pageNum && i <= lastPageNum; i++) {
         pageList.push(i);
@@ -55,7 +55,7 @@ const Pagination = ({
   // 페이지 숫자 양 옆의 화살표 버튼 클릭 시 실행할 함수
   const handlePaginationArrowButton = (rightDirection: boolean) => {
     if (rightDirection) {
-      if (currentPage !== lastPageNum && lastPageNum !== 1) {
+      if (currentPage < lastPageNum && lastPageNum !== 1) {
         handlePageNumberChange(currentPage + 1);
       }
     } else {
@@ -115,7 +115,7 @@ const Pagination = ({
       <button
         type="button"
         className={`relative h-5 w-5 rounded-full 
-          ${currentPage !== lastPageNum && lastPageNum !== 1 ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
+          ${currentPage < lastPageNum ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
         onClick={() => handlePaginationArrowButton(true)}
       >
         <PaginationArrow className="h-full w-full" />

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -14,11 +14,9 @@ interface PaginationProps {
 
 /**
  * @param {number} count 현재 페이지네이션할 데이터의 총량을 받습니다.
- * @param {number} pageItemLimit 현재 페이지에 얼마나 많은 개수를 표기할 지 선택하는 인수입니다. 기본적으로 코드잇에서 제공하는 5값으로 되어있으며 필요시 추가로 수정할 수 있게 하였습니다.
- * @param {pageData[]} rawPageData 페이지에 표시할 순수 배열 데이터를 받는 param입니다. 이 데이터를 가공하여 [페이지][페이지 데이터] 형태의 2차원 배열로 가공합니다.
- * @param {React.Dispatch<SetStateAction>} setCurrentPageData 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다.
- * @param {boolean} pageRefreshSwitch boolean 형이 변화할 때 마다 바뀌었다는 것을 알려주는 인자입니다. setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
- * @param {React.Dispatch<React.SetStateAction<boolean>>} setIsFilterChanged 페이지 이동할때 filter변경이 이뤄지지 않는다고 세팅을 해줘야해서 받는 setter함수입니다.
+ * @param {number} pageItemLimit 현재 페이지에 얼마나 많은 개수를 표기할 지 선택하는 인수입니다. 기본적으로 리뷰 컴포넌트에서 표시하는 3값으로 설정되어있습니다.
+ * @param {function} onPageClick 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다.
+ * @param {boolean} pageRefreshSwitch 현재 페이지가 변화하여 1페이지로 돌아가야 함을 알려줄 때 사용합니다. setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
  * @returns
  */
 const Pagination = ({

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -35,7 +35,7 @@ const Pagination = ({
   const handlePageNumberChange = (pageNum: number) => {
     setCurrentPage(pageNum);
     onPageClick(pageNum);
-    if (pageNum % 5 === 1 && pageNum < lastPageNum) {
+    if (pageNum % 5 === 1 && pageNum <= lastPageNum) {
       const pageList = [];
       for (let i = pageNum; i <= pageNum + 4 && i <= lastPageNum; i++) {
         pageList.push(i);
@@ -43,7 +43,7 @@ const Pagination = ({
       setCurrentPageList(pageList);
     }
 
-    if (pageNum % 5 === 0 && pageNum < lastPageNum) {
+    if (pageNum % 5 === 0 && pageNum <= lastPageNum) {
       const pageList = [];
       for (let i = pageNum - 4; i <= pageNum && i <= lastPageNum; i++) {
         pageList.push(i);

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PaginationArrow from "./PaginationArrow";
 
 interface PaginationProps {
@@ -13,7 +13,7 @@ interface PaginationProps {
 /**
  * @param {number} count 현재 페이지네이션할 데이터의 총량을 받습니다.
  * @param {number} pageItemLimit 현재 페이지에 얼마나 많은 개수를 표기할 지 선택하는 인수입니다. 기본적으로 리뷰 컴포넌트에서 표시하는 3값으로 설정되어있습니다.
- * @param {function} onPageClick 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다.
+ * @param {function} onPageClick 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다. 동일 페이지 내 화면 이동이 필요한 경우, useRef를 활용해 ref.current.scrollIntoView를 활용하시면 될 것 같습니다.
  * @param {boolean} pageRefreshSwitch 현재 페이지가 변화하여 1페이지로 돌아가야 함을 알려줄 때 사용합니다. ex)filter적용 setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
  * @returns
  */

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -5,7 +5,7 @@ import PaginationArrow from "./PaginationArrow";
 
 interface PaginationProps {
   count: number;
-  setCurrentPageData: (currentPageData: number) => void;
+  onPageClick: (currentPageData: number) => void;
   pageItemLimit?: number;
   pageRefreshSwitch?: boolean;
   enableAnchorNavigation?: boolean;
@@ -24,47 +24,54 @@ interface PaginationProps {
 const Pagination = ({
   count,
   pageItemLimit = 3,
-  setCurrentPageData,
+  onPageClick = () => {},
   pageRefreshSwitch,
-  setIsFilterChanged,
 }: PaginationProps) => {
-  const pageData = Math.ceil(count / pageItemLimit);
+  const lastPageNum = Math.ceil(count / pageItemLimit);
   const [currentPage, setCurrentPage] = useState(1);
-  const [currentPageList, setCurrentPageList] = useState([1, 2, 3, 4, 5]);
+  const [currentPageList, setCurrentPageList] = useState([1]);
 
   // 페이지 번호 설정에 따라 발생시킬 함수
-  const handlePageNumberChange = (index: number) => {
-    setIsFilterChanged?.(false);
-    setCurrentPage(index);
-    setCurrentPageData(index);
+  const handlePageNumberChange = (pageNum: number) => {
+    setCurrentPage(pageNum);
+    onPageClick(pageNum);
+    if (pageNum % 5 === 1) {
+      const pageList = [];
+      for (let i = pageNum; i <= pageNum + 4 && i <= lastPageNum; i++) {
+        pageList.push(i);
+      }
+      setCurrentPageList(pageList);
+    }
+
+    if (pageNum % 5 === 0) {
+      const pageList = [];
+      for (let i = pageNum - 4; i <= pageNum && i <= lastPageNum; i++) {
+        pageList.push(i);
+      }
+      setCurrentPageList(pageList);
+    }
   };
 
   // 페이지 숫자 양 옆의 화살표 버튼 클릭 시 실행할 함수
-  const handlePaginationArrowButton = (direction: string) => {
-    setIsFilterChanged?.(false);
-    switch (direction) {
-      case "left":
-        if (currentPage !== 1) {
-          handlePageNumberChange(currentPage - 1);
-        }
-        break;
-      case "right":
-        if (currentPage !== pageData && pageData !== 1) {
-          handlePageNumberChange(currentPage + 1);
-        }
-        break;
-      default:
-        console.error("이게 뜨면 안됨");
+  const handlePaginationArrowButton = (rightDirection: boolean) => {
+    if (rightDirection) {
+      if (currentPage !== lastPageNum && lastPageNum !== 1) {
+        handlePageNumberChange(currentPage + 1);
+      }
+    } else {
+      if (currentPage !== 1) {
+        handlePageNumberChange(currentPage - 1);
+      }
     }
   };
 
   useEffect(() => {
     const firstPageList: number[] = [];
 
-    if (pageData === 0) {
+    if (lastPageNum === 0) {
       firstPageList.push(1);
     } else {
-      for (let i = 1; i <= pageData; i++) {
+      for (let i = 1; i <= 5 && i <= lastPageNum; i++) {
         firstPageList.push(i);
       }
     }
@@ -85,18 +92,18 @@ const Pagination = ({
         type="button"
         className={`h-5 w-5 rounded-full 
           ${currentPage !== 1 ? "hover:bg-gray-20" : "cursor-default opacity-40"}`}
-        onClick={() => handlePaginationArrowButton("left")}
+        onClick={() => handlePaginationArrowButton(false)}
       >
         <PaginationArrow className="h-full w-full rotate-180" />
       </button>
 
-      <div className="flex gap-2.5">
+      <div className="flex min-w-80 justify-center gap-2.5">
         {currentPageList.map((item) => (
           <React.Fragment key={`pagination-${item}`}>
             <button
               type="button"
               className={`h-14 w-14 rounded-2xl border border-black
-            ${currentPage === item ? "bg-nomad-black text-white" : "text-black hover:bg-white"}`}
+            ${currentPage === item ? "bg-nomad-black text-white" : "text-black hover:bg-gray-10"}`}
               onClick={() => handlePageNumberChange(item)}
             >
               {item}
@@ -108,8 +115,8 @@ const Pagination = ({
       <button
         type="button"
         className={`relative h-5 w-5 rounded-full 
-          ${currentPage !== pageData && pageData !== 1 ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
-        onClick={() => handlePaginationArrowButton("right")}
+          ${currentPage !== lastPageNum && lastPageNum !== 1 ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
+        onClick={() => handlePaginationArrowButton(true)}
       >
         <PaginationArrow className="h-full w-full" />
       </button>

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import React, { SetStateAction, useEffect, useState } from "react";
+import PaginationArrow from "./PaginationArrow";
+
+interface PaginationProps {
+  count: number;
+  setCurrentPageData: (currentPageData: number) => void;
+  pageItemLimit?: number;
+  pageRefreshSwitch?: boolean;
+  enableAnchorNavigation?: boolean;
+  setIsFilterChanged?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+/**
+ * @param {number} count 현재 페이지네이션할 데이터의 총량을 받습니다.
+ * @param {number} pageItemLimit 현재 페이지에 얼마나 많은 개수를 표기할 지 선택하는 인수입니다. 기본적으로 코드잇에서 제공하는 5값으로 되어있으며 필요시 추가로 수정할 수 있게 하였습니다.
+ * @param {pageData[]} rawPageData 페이지에 표시할 순수 배열 데이터를 받는 param입니다. 이 데이터를 가공하여 [페이지][페이지 데이터] 형태의 2차원 배열로 가공합니다.
+ * @param {React.Dispatch<SetStateAction>} setCurrentPageData 현재 페이지에 보여줄 데이터를 설정하는 setState함수를 받아 페이지 선택 시 그 값으로 설정합니다.
+ * @param {boolean} pageRefreshSwitch boolean 형이 변화할 때 마다 바뀌었다는 것을 알려주는 인자입니다. setState(!state) 형식으로 초기화가 필요한 작업 끝단에 넣어주시면 될 듯 합니다.
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} setIsFilterChanged 페이지 이동할때 filter변경이 이뤄지지 않는다고 세팅을 해줘야해서 받는 setter함수입니다.
+ * @returns
+ */
+const Pagination = ({
+  count,
+  pageItemLimit = 3,
+  setCurrentPageData,
+  pageRefreshSwitch,
+  setIsFilterChanged,
+}: PaginationProps) => {
+  const pageData = Math.ceil(count / pageItemLimit);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPageList, setCurrentPageList] = useState([1, 2, 3, 4, 5]);
+
+  // 페이지 번호 설정에 따라 발생시킬 함수
+  const handlePageNumberChange = (index: number) => {
+    setIsFilterChanged?.(false);
+    setCurrentPage(index);
+    setCurrentPageData(index);
+  };
+
+  // 페이지 숫자 양 옆의 화살표 버튼 클릭 시 실행할 함수
+  const handlePaginationArrowButton = (direction: string) => {
+    setIsFilterChanged?.(false);
+    switch (direction) {
+      case "left":
+        if (currentPage !== 1) {
+          handlePageNumberChange(currentPage - 1);
+        }
+        break;
+      case "right":
+        if (currentPage !== pageData && pageData !== 1) {
+          handlePageNumberChange(currentPage + 1);
+        }
+        break;
+      default:
+        console.error("이게 뜨면 안됨");
+    }
+  };
+
+  useEffect(() => {
+    const firstPageList: number[] = [];
+
+    if (pageData === 0) {
+      firstPageList.push(1);
+    } else {
+      for (let i = 1; i <= pageData; i++) {
+        firstPageList.push(i);
+      }
+    }
+
+    setCurrentPageList(firstPageList);
+    handlePageNumberChange(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [count]);
+
+  useEffect(() => {
+    handlePageNumberChange(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageRefreshSwitch]);
+
+  return (
+    <div className="flex h-16 w-full items-center justify-center gap-2 bg-white p-3 ">
+      <button
+        type="button"
+        className={`h-5 w-5 rounded-full 
+          ${currentPage !== 1 ? "hover:bg-gray-20" : "cursor-default opacity-40"}`}
+        onClick={() => handlePaginationArrowButton("left")}
+      >
+        <PaginationArrow className="h-full w-full rotate-180" />
+      </button>
+
+      <div className="flex gap-2.5">
+        {currentPageList.map((item) => (
+          <React.Fragment key={`pagination-${item}`}>
+            <button
+              type="button"
+              className={`h-14 w-14 rounded-2xl border border-black
+            ${currentPage === item ? "bg-nomad-black text-white" : "text-black hover:bg-white"}`}
+              onClick={() => handlePageNumberChange(item)}
+            >
+              {item}
+            </button>
+          </React.Fragment>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        className={`relative h-5 w-5 rounded-full 
+          ${currentPage !== pageData && pageData !== 1 ? " hover:bg-gray-20" : "cursor-default opacity-40"}`}
+        onClick={() => handlePaginationArrowButton("right")}
+      >
+        <PaginationArrow className="h-full w-full" />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/components/common/svg/Arrow.tsx
+++ b/components/common/svg/Arrow.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
-interface PaginationArrow {
+interface Arrow {
   width?: number;
   height?: number;
   color?: string;
   className?: string;
 }
 
-const PaginationArrow = ({
+const Arrow = ({
   width = 40,
   height = 40,
   color = "#4B4B4B",
   className = "",
-}: PaginationArrow) => {
+}: Arrow) => {
   return (
     <svg
       className={className}
@@ -35,4 +35,4 @@ const PaginationArrow = ({
   );
 };
 
-export default PaginationArrow;
+export default Arrow;

--- a/public/icons/arrow.svg
+++ b/public/icons/arrow.svg
@@ -1,0 +1,5 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Property 1=Variant4">
+<path id="Vector 668" d="M16 11L26.2929 21.2929C26.6834 21.6834 26.6834 22.3166 26.2929 22.7071L16 33" stroke="#4B4B4B" stroke-width="3" stroke-linecap="round"/>
+</g>
+</svg>


### PR DESCRIPTION
## 🚀 작업 내용 #20 

- 페이지의 이동을 시각적으로 보여줄 페이지네이션 컴포넌트입니다.
  - 좌우 화살표의 클릭에 따라 페이지가 증감됩니다.
  - 페이지 목록의 끝 페이지에 도달했을 경우, 화살표 클릭시 다음 페이지 목록을 보여줍니다.
  - onPageClick프롭 함수를 받아 이동하고자 하는 페이지를 누를 때 마다 해당 함수를 실행합니다.

## 📝 참고 사항

- 동일 페이지 내 화면 이동이 필요한 경우 ref.current.scrollIntoView기능을 onPageClick에 넣어주시면 될 것 같습니다.

## 🖼️ 스크린샷


### 1페이지만 있을 경우, 이동이 불가하며 화살표가 옅은 회색으로 표시됩니다.
<img width="368" alt="스크린샷 2024-05-30 오후 4 46 28" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/5e1e5f2a-c511-48ed-8f6d-59b81b830770">
<img width="438" alt="스크린샷 2024-05-30 오후 4 46 41" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/004c13ab-ae4b-4689-9ef6-c646c48db5f0">

### 현재 선택된 페이지의 이동에 따라 페이지 목록이 변화합니다.
<img width="396" alt="스크린샷 2024-05-30 오후 4 47 53" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/60558a67-aa5a-4f7f-8786-ffaa30a156c0">
<img width="417" alt="스크린샷 2024-05-30 오후 4 48 01" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/15b977b8-d98b-4575-9ccd-1be11e4ac940">
<img width="494" alt="스크린샷 2024-05-30 오후 4 48 06" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/4990888e-71c6-4ece-a4a3-0c5d46e8ed78">

### 모바일 화면입니다. 현재 사양으로는 300px 사이즈까지 어그러지지 않습니다.
<img width="341" alt="스크린샷 2024-05-30 오후 4 52 27" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/c2b5f749-4b24-4d5d-9df5-577dcc4622a0">





## 🚨 관련 이슈

- #20 
