### PR TITLE
[PFTF-24] Popup 컴포넌트 작업

### DIFF
--- a/components/common/Popup/CancelPopup.tsx
+++ b/components/common/Popup/CancelPopup.tsx
@@ -9,12 +9,12 @@ interface CancelPopupProps {
   onCancel: () => void;
 }
 
-const CancelPopup: React.FC<CancelPopupProps> = ({
+const CancelPopup = ({
   message,
   isOpen,
   onClose,
   onCancel,
-}) => {
+}: CancelPopupProps) => {
   return (
     <PopupWrapper isOpen={isOpen} onClose={onClose}>
       <div className="flex w-72 flex-col items-center justify-center rounded-xl bg-white p-6">

--- a/components/common/Popup/CancelPopup.tsx
+++ b/components/common/Popup/CancelPopup.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import PopupWrapper from "./PopupWrapper";
+import Button from "../Button";
+import CloseSvg from "../svg/PopupCheckSvg";
+
+interface CancelPopupProps {
+  message: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onCancel: () => void;
+}
+
+const CancelPopup: React.FC<CancelPopupProps> = ({
+  message,
+  isOpen,
+  onClose,
+  onCancel,
+}) => {
+  return (
+    <PopupWrapper isOpen={isOpen} onClose={onClose}>
+      <div className="flex w-72 flex-col items-center justify-center rounded-xl bg-white p-6">
+        <CloseSvg />
+        <p className="mt-4">{message}</p>
+        <div className="mt-8 flex justify-center gap-3">
+          <Button variant="white" size="sm" onClick={onClose}>
+            아니오
+          </Button>
+          <Button
+            onClick={() => {
+              onClose();
+              onCancel();
+            }}
+            size="sm"
+          >
+            취소하기
+          </Button>
+        </div>
+      </div>
+    </PopupWrapper>
+  );
+};
+
+export default CancelPopup;

--- a/components/common/Popup/CancelPopup.tsx
+++ b/components/common/Popup/CancelPopup.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PopupWrapper from "./PopupWrapper";
 import Button from "../Button";
 import CloseSvg from "../svg/PopupCheckSvg";

--- a/components/common/Popup/DeletePopup.tsx
+++ b/components/common/Popup/DeletePopup.tsx
@@ -1,0 +1,42 @@
+import PopupWrapper from "./PopupWrapper";
+import Button from "../Button";
+import PopupCheckSvg from "../svg/PopupCheckSvg";
+
+interface DeletePopupProps {
+  message: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+const DeletePopup = ({
+  message,
+  isOpen,
+  onClose,
+  onDelete,
+}: DeletePopupProps) => {
+  return (
+    <PopupWrapper isOpen={isOpen} onClose={onClose}>
+      <div className="flex w-72 flex-col items-center justify-center rounded-xl bg-white p-6">
+        <PopupCheckSvg />
+        <p className="mt-4">{message}</p>
+        <div className="mt-8 flex justify-center gap-3">
+          <Button variant="white" size="sm" onClick={onClose}>
+            아니오
+          </Button>
+          <Button
+            onClick={() => {
+              onClose();
+              onDelete();
+            }}
+            size="sm"
+          >
+            삭제하기
+          </Button>
+        </div>
+      </div>
+    </PopupWrapper>
+  );
+};
+
+export default DeletePopup;

--- a/components/common/Popup/NotificationPopup.tsx
+++ b/components/common/Popup/NotificationPopup.tsx
@@ -1,0 +1,31 @@
+import Button from "../Button";
+import PopupWrapper from "./PopupWrapper";
+
+interface NotificationPopupProps {
+  message: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const NotificationPopup = ({
+  message,
+  isOpen,
+  onClose,
+}: NotificationPopupProps) => {
+  return (
+    <PopupWrapper isOpen={isOpen} onClose={onClose}>
+      <div className="m-3 flex h-[220px] w-[327px] max-w-full flex-col items-center justify-between rounded-xl bg-white p-6 md:h-[250px] md:w-[540px]">
+        <div className="flex flex-grow items-center justify-center">
+          <p className="text-center">{message}</p>
+        </div>
+        <div className="flex w-full justify-center md:justify-end">
+          <Button onClick={onClose} size="md">
+            확인
+          </Button>
+        </div>
+      </div>
+    </PopupWrapper>
+  );
+};
+
+export default NotificationPopup;

--- a/components/common/Popup/PopupWrapper.tsx
+++ b/components/common/Popup/PopupWrapper.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useEffect, useRef } from "react";
+
+interface PopupWrapperProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+const PopupWrapper = ({ isOpen, onClose, children }: PopupWrapperProps) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+      if (wrapperRef.current) {
+        wrapperRef.current.focus();
+      }
+    } else {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      tabIndex={-1}
+      ref={wrapperRef}
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+    >
+      {children}
+    </div>
+  );
+};
+
+export default PopupWrapper;

--- a/components/common/svg/PopupCheckSvg.tsx
+++ b/components/common/svg/PopupCheckSvg.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const CloseSvg = () => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="12" fill="#112211" />
+      <path
+        d="M7.60693 12.3491L10.6873 15.5L16.2498 8.35718"
+        stroke="white"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default CloseSvg;

--- a/components/test/PopupTest.tsx
+++ b/components/test/PopupTest.tsx
@@ -1,0 +1,62 @@
+"use client";
+import useToggle from "@/hooks/useToggle";
+import CancelPopup from "../common/Popup/CancelPopup";
+import DeletePopup from "../common/Popup/DeletePopup";
+import NotificationPopup from "../common/Popup/NotificationPopup";
+
+const PopupTest = () => {
+  const { isOpen: isNotificationOpen, toggle: toggleNotification } =
+    useToggle();
+  const { isOpen: isCancelOpen, toggle: toggleCancel } = useToggle();
+  const { isOpen: isDeleteOpen, toggle: toggleDelete } = useToggle();
+
+  const handleCancel = () => {
+    console.log("예약이 취소되었습니다.");
+  };
+
+  const handleDelete = () => {
+    console.log("항목이 삭제되었습니다.");
+  };
+
+  return (
+    <div>
+      <button
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+        onClick={toggleNotification}
+      >
+        알림 팝업 열기
+      </button>
+      <button
+        className="rounded bg-green-500 px-4 py-2 text-white"
+        onClick={toggleCancel}
+      >
+        예약 취소 팝업 열기
+      </button>
+      <button
+        className="rounded bg-red-500 px-4 py-2 text-white"
+        onClick={toggleDelete}
+      >
+        삭제 팝업 열기
+      </button>
+      <NotificationPopup
+        message="성공적으로 회원가입에 성공하였습니다!"
+        isOpen={isNotificationOpen}
+        onClose={toggleNotification}
+      />
+      <CancelPopup
+        message="정말로 예약을 취소하시겠습니까?"
+        isOpen={isCancelOpen}
+        onClose={toggleCancel}
+        onCancel={handleCancel}
+      />
+      <DeletePopup
+        message="정말로 항목을 삭제하시겠습니까?"
+        isOpen={isDeleteOpen}
+        onClose={toggleDelete}
+        onDelete={handleDelete}
+      />
+    </div>
+  );
+};
+
+export default PopupTest;

--- a/hooks/useToggle.ts
+++ b/hooks/useToggle.ts
@@ -1,0 +1,13 @@
+import { useState, useCallback } from "react";
+
+const useToggle = (initialState: boolean = false) => {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return { isOpen, toggle };
+};
+
+export default useToggle;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 로그인, 회원가입, 예약취소, 예약삭제 기능에서 사용
- [x] 각 popup 스타일을 만들어서 필요한 곳에서 재사용할 수 있도록 구현

## 📝 참고 사항

- 사용자 인터렉션에 의해 단순한 메시지 전달 용도와 사용자에의한 요청을 결정하고 있고 각자의 액션이 다르기 때문에 팝업관련 컴포넌트(알림,취소,삭제)를 분리하였습니다.
- 단순히 열고 닫을 수 있는 로직이 많아 토글관련 훅을 추가하였습니다. (후에 제거하거나 수정 가능)
- PopupWrapper 컴포넌트에서 엔터키 입력을 받으면 팝업창이 닫히게 하였습니다.( 추후 수정 및 삭제 가능 )
- 현재 버튼 컴포넌트에 variant 속성엔 red 속성이 없어 삭제팝업에서 임시로 default를 사용하고 있습니다. ( 추후 추가 가능 ) 

## 🖼️ 스크린샷
![스크린샷 2024-06-02 오후 9 27 56](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/100824183/51b0ddaa-cfd8-46ed-9f2d-afa571f0211c)
![스크린샷 2024-06-02 오후 9 28 05](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/100824183/c086c68a-8dc4-4329-85ce-9aa3cfd246d5)
![스크린샷 2024-06-02 오후 9 28 09](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/100824183/00338b38-e97a-4b46-9235-3b32c4c11b46)
![스크린샷 2024-06-02 오후 9 28 14](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/100824183/d5ada9f2-688a-46f0-b3d5-ed7b5a732002)



## 🚨 관련 이슈

- #24 
