### PR TITLE
[PFTF-19] Category 컴포넌트 구현완료

### DIFF
--- a/components/common/Category.tsx
+++ b/components/common/Category.tsx
@@ -22,7 +22,7 @@ export const CategoryItem = ({
 }: CategoryItemProps) => {
   return (
     <button
-      className={`${isSelected ? "bg-nomad-black" : "bg-white"} ${isSelected ? "text-white" : "bg-white"} w-[90px] rounded-[15px] border-[1px] border-green-20 px-[16px] py-[12px]  text-center text-[14px] font-[400] leading-normal tracking-tighter hover:bg-nomad-black hover:text-white md:w-[120px] md:px-[24px] md:py-[16px] md:text-[18px] xl:w-[127px]`}
+      className={`${isSelected ? "bg-nomad-black" : "bg-white"} ${isSelected ? "text-white" : "bg-white"} w-[90px] rounded-[15px] border-[1px] border-green-20 px-[16px] py-[12px]  text-center text-[14px] font-[400] leading-normal tracking-tighter hover:bg-nomad-black hover:text-white min-[720px]:w-[120px] min-[720px]:px-[24px] min-[720px]:py-[16px] min-[720px]:text-[18px] min-[830px]:w-[127px]`}
       onClick={onClick}
     >
       {children}
@@ -32,7 +32,7 @@ export const CategoryItem = ({
 
 export const Category = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [isEndPointScroll, setisEndPointScroll] = useState<boolean>(false);
+  const [isEndPointScroll, setIsEndPointScroll] = useState<boolean>(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const handleCategoryClick = (category: string) => {
@@ -41,20 +41,20 @@ export const Category = () => {
     } else {
       setSelectedCategory(category);
     }
+    handleScroll();
+  };
+
+  const handleScroll = () => {
+    if (scrollRef.current) {
+      const { scrollLeft, clientWidth, scrollWidth } = scrollRef.current;
+      setIsEndPointScroll(scrollLeft + clientWidth >= scrollWidth);
+    }
   };
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (scrollRef.current) {
-        const { scrollLeft, clientWidth, scrollWidth } = scrollRef.current;
-        setisEndPointScroll(scrollLeft + clientWidth >= scrollWidth);
-      }
-    };
-
     const scrollElement = scrollRef.current;
     if (scrollElement) {
       scrollElement.addEventListener("scroll", handleScroll);
-      handleScroll();
     }
 
     return () => {
@@ -67,13 +67,13 @@ export const Category = () => {
   return (
     <div>
       {!isEndPointScroll && (
-        <div className="pointer-events-none absolute z-0 h-[47px] w-[230px] bg-gradient-to-r from-transparent via-transparent via-70% to-white to-100% md:h-[61px] md:w-[523px] xl:hidden xl:w-[882px] " />
+        <div className="pointer-events-none absolute z-0 h-[47px] w-[220px] bg-gradient-to-r from-transparent via-transparent via-70% to-white to-100% min-[450px]:w-[270px] min-[550px]:w-[370px] min-[720px]:h-[61px] min-[720px]:w-[523px] min-[980px]:w-[732px] min-[1080px]:hidden min-[1080px]:w-[882px]" />
       )}
       <div
         ref={scrollRef}
-        className="z-10 w-[230px] touch-pan-x snap-start overflow-hidden overflow-x-auto bg-transparent md:w-[523px] xl:w-[882px] [&::-webkit-scrollbar]:hidden"
+        className="z-10 w-[220px] touch-pan-x snap-start overflow-hidden overflow-x-auto bg-transparent min-[450px]:w-[270px] min-[550px]:w-[370px] min-[720px]:w-[523px] min-[980px]:w-[732px] min-[1080px]:w-[882px] [&::-webkit-scrollbar]:hidden"
       >
-        <div className="flex w-[580px] gap-[8px] md:w-[790px] md:gap-[14px] xl:w-[882px] xl:gap-[24px]">
+        <div className="flex w-[580px] gap-[8px] min-[720px]:w-[790px] min-[720px]:gap-[14px] min-[830px]:w-[882px] min-[830px]:gap-[24px]">
           {CATEGORY_LIST.map((item: string) => {
             return (
               <CategoryItem

--- a/components/common/Category.tsx
+++ b/components/common/Category.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 
 interface CategoryItemProps {
   children: ReactNode;
@@ -32,6 +32,8 @@ export const CategoryItem = ({
 
 export const Category = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [isEndPointScroll, setisEndPointScroll] = useState<boolean>(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const handleCategoryClick = (category: string) => {
     if (selectedCategory === category) {
@@ -41,10 +43,36 @@ export const Category = () => {
     }
   };
 
+  useEffect(() => {
+    const handleScroll = () => {
+      if (scrollRef.current) {
+        const { scrollLeft, clientWidth, scrollWidth } = scrollRef.current;
+        setisEndPointScroll(scrollLeft + clientWidth >= scrollWidth);
+      }
+    };
+
+    const scrollElement = scrollRef.current;
+    if (scrollElement) {
+      scrollElement.addEventListener("scroll", handleScroll);
+      handleScroll();
+    }
+
+    return () => {
+      if (scrollElement) {
+        scrollElement.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, []);
+
   return (
     <div>
-      <div className="pointer-events-none absolute z-0 h-[47px] w-[230px] bg-gradient-to-r from-transparent via-transparent via-70% to-white to-100% md:h-[61px] md:w-[523px] xl:hidden xl:w-[882px] " />
-      <div className="z-10 w-[230px] touch-pan-x snap-start overflow-hidden overflow-x-auto bg-transparent md:w-[523px] xl:w-[882px] [&::-webkit-scrollbar]:hidden">
+      {!isEndPointScroll && (
+        <div className="pointer-events-none absolute z-0 h-[47px] w-[230px] bg-gradient-to-r from-transparent via-transparent via-70% to-white to-100% md:h-[61px] md:w-[523px] xl:hidden xl:w-[882px] " />
+      )}
+      <div
+        ref={scrollRef}
+        className="z-10 w-[230px] touch-pan-x snap-start overflow-hidden overflow-x-auto bg-transparent md:w-[523px] xl:w-[882px] [&::-webkit-scrollbar]:hidden"
+      >
         <div className="flex w-[580px] gap-[8px] md:w-[790px] md:gap-[14px] xl:w-[882px] xl:gap-[24px]">
           {CATEGORY_LIST.map((item: string) => {
             return (

--- a/components/common/Category.tsx
+++ b/components/common/Category.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode, useState } from "react";
+
+interface CategoryItemProps {
+  children: ReactNode;
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+const CATEGORY_LIST = [
+  "문화 · 예술",
+  "식음료",
+  "스포츠",
+  "투어",
+  "관광",
+  "웰빙",
+];
+
+export const CategoryItem = ({
+  children,
+  isSelected,
+  onClick,
+}: CategoryItemProps) => {
+  return (
+    <button
+      className={`${isSelected ? "bg-nomad-black" : "bg-white"} ${isSelected ? "text-white" : "bg-white"} w-[90px] rounded-[15px] border-[1px] border-green-20 px-[16px] py-[12px]  text-center text-[14px] font-[400] leading-normal tracking-tighter hover:bg-nomad-black hover:text-white md:w-[120px] md:px-[24px] md:py-[16px] md:text-[18px] xl:w-[127px]`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const Category = () => {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const handleCategoryClick = (category: string) => {
+    if (selectedCategory === category) {
+      setSelectedCategory(null);
+    } else {
+      setSelectedCategory(category);
+    }
+  };
+
+  return (
+    <div>
+      <div className="pointer-events-none absolute z-0 h-[47px] w-[230px] bg-gradient-to-r from-transparent via-transparent via-70% to-white to-100% md:h-[61px] md:w-[523px] xl:hidden xl:w-[882px] " />
+      <div className="z-10 w-[230px] touch-pan-x snap-start overflow-hidden overflow-x-auto bg-transparent md:w-[523px] xl:w-[882px] [&::-webkit-scrollbar]:hidden">
+        <div className="flex w-[580px] gap-[8px] md:w-[790px] md:gap-[14px] xl:w-[882px] xl:gap-[24px]">
+          {CATEGORY_LIST.map((item: string) => {
+            return (
+              <CategoryItem
+                key={item}
+                isSelected={item === selectedCategory}
+                onClick={() => handleCategoryClick(item)}
+              >
+                {item}
+              </CategoryItem>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🚀 작업 내용

- 클릭했을 때의 UI변경 적용
- 상위 컴포넌트에서 onClick 함수 prop을 받을 수 있게 설계
- 상위 컴포넌트에서 카테고리명 children을 받을 수 있게 설계
- 반응형 UI 적용
- mobile, tablet 기준에서 사용중인 그라데이션 효과를 항목 마지막으로 이동하면 사라지게 적용

## 📝 참고 사항

- 필터에 자리에 임의의 컴포넌트를 두고 테스트 하였습니다.

## 🖼️ 스크린샷

## mobile 기준

https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/97032929/c0830e4d-a0a6-44d1-97e1-2fab878e5e27

https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/97032929/abdb0a66-d2d9-444c-81de-c3fed3898d77

## tablet 기준
<img width="380" alt="스크린샷 2024-06-03 오후 2 21 06" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/97032929/7b505b3c-df40-4939-82f9-437a3b23fb28">

## desktop 기준
<img width="954" alt="스크린샷 2024-06-03 오후 2 21 24" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/97032929/2ac9f02c-c774-4257-b1ed-ec76c0670640">

## 🚨 관련 이슈

- #19
