### PR TITLE
[PFTF-80] modalPortal 리렌더링 픽스

### DIFF
--- a/components/common/ModalBase.tsx
+++ b/components/common/ModalBase.tsx
@@ -1,0 +1,54 @@
+"use client";
+import React, { Dispatch, SetStateAction } from "react";
+import Button from "./Button";
+
+interface ReservationPopupType {
+  title: string;
+  setState: Dispatch<SetStateAction<boolean>>;
+  buttonName?: string;
+  onButtonClick?: () => void;
+  usePortal?: boolean;
+  children: React.ReactNode;
+}
+
+const ModalBase = ({
+  title,
+  setState,
+  buttonName,
+  onButtonClick,
+  usePortal,
+  children,
+}: ReservationPopupType) => {
+  return (
+    <>
+      {usePortal && (
+        <div className="md:fixed md:left-0 md:top-0 md:h-screen md:w-screen md:bg-black md:opacity-70" />
+      )}
+      <div
+        className={`md:outline-1px fixed flex h-screen w-screen flex-col justify-between bg-white p-6 pb-10 shadow-sm md:h-min md:w-[30rem] md:rounded-xl md:pb-8 md:outline md:outline-[#A4a1aa]
+                  ${
+                    usePortal
+                      ? "right-0 top-0 md:fixed md:right-1/2 md:top-1/2 md:-translate-y-1/2 md:translate-x-1/2"
+                      : "right-0 top-0 md:absolute"
+                  } `}
+      >
+        <div className="mb-16">
+          <header className="mb-8 flex items-center justify-between text-[1.75rem] font-bold leading-[1.675rem]">
+            {title}
+            <button
+              type="button"
+              onClick={() => setState(false)}
+              className="h-10 w-10 bg-[url('/icons/btn_X.svg')]"
+            ></button>
+          </header>
+          {children}
+        </div>
+        {buttonName && (
+          <Button onClick={() => onButtonClick!()}>{buttonName}</Button>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ModalBase;

--- a/components/common/ModalPortal.tsx
+++ b/components/common/ModalPortal.tsx
@@ -1,7 +1,14 @@
 "use client";
 import Button from "@/components/common/Button";
-import React, { Dispatch, SetStateAction } from "react";
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import ReactDOM from "react-dom";
+import ModalBase from "./ModalBase";
 
 interface ReservationPopupType {
   title: string;
@@ -11,6 +18,7 @@ interface ReservationPopupType {
   usePortal?: boolean;
   children: React.ReactNode;
 }
+
 /**
  *
  * @param {string} title 현재 모달의 이름입니다.
@@ -21,6 +29,7 @@ interface ReservationPopupType {
  * @param {boolean} usePortal 현재 모달이 portal기능을 사용하여 표시할 것인지를 받습니다. 기본적으로 false상태입니다.
  * @returns
  */
+
 const ReservationPopup = ({
   title,
   setState,
@@ -29,37 +38,39 @@ const ReservationPopup = ({
   children,
   usePortal = false,
 }: ReservationPopupType) => {
-  const ModalBase = () => (
-    <>
-      {usePortal && (
-        <div className="md:fixed md:left-0 md:top-0 md:h-screen md:w-screen md:bg-black md:opacity-70" />
-      )}
-      <div
-        className={`md:outline-1px fixed flex h-screen w-screen flex-col justify-between bg-white p-6 pb-10 shadow-sm md:absolute md:h-min md:w-[30rem] md:rounded-xl md:pb-8 md:outline md:outline-[#A4a1aa]
-                  ${usePortal ? "fixed right-0 top-0 md:right-1/2 md:top-1/2 md:-translate-y-1/2 md:translate-x-1/2" : "right-0 top-0"} `}
+  const [mounted, setMounted] = useState(false);
+  // const portalElement = useMemo(() => document.getElementById("portal"), []);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (usePortal && mounted) {
+    const portalElement = document.getElementById("portal");
+    return ReactDOM.createPortal(
+      <ModalBase
+        title={title}
+        setState={setState}
+        buttonName={buttonName}
+        onButtonClick={onButtonClick}
+        usePortal={usePortal}
       >
-        <div className="mb-16">
-          <header className="mb-8 flex items-center justify-between text-[1.75rem] font-bold leading-[1.675rem]">
-            {title}
-            <button
-              type="button"
-              onClick={() => setState(false)}
-              className="h-10 w-10 bg-[url('/icons/btn_X.svg')]"
-            ></button>
-          </header>
-          {children}
-        </div>
-        {buttonName && (
-          <Button onClick={() => onButtonClick!()}>{buttonName}</Button>
-        )}
-      </div>
-    </>
-  );
-  if (usePortal) {
-    const el = document.getElementById("portal");
-    return ReactDOM.createPortal(<ModalBase />, el!);
+        {children}
+      </ModalBase>,
+      portalElement!,
+    );
   }
-  return <ModalBase />;
+
+  return (
+    <ModalBase
+      title={title}
+      setState={setState}
+      buttonName={buttonName}
+      onButtonClick={onButtonClick}
+      usePortal={usePortal}
+    >
+      {children}
+    </ModalBase>
+  );
 };
 
 export default ReservationPopup;


### PR DESCRIPTION
## 🚀 작업 내용

- 컴포넌트 내에 컴포넌트를 선언하여, 내용 변형이 일어날 때마다 컴포넌트 리렌더링이 발생하여 초기화되는 문제를 해결하였습니다.
- modal 내부에 있던 state가 변경될때, state가 초기화되는 현상 또한 고쳐졌습니다.
- usePortal을 통해 fixed style을 적용할때 생겼던 스타일 문제를 해결했습니다.

## 📝 참고 사항

- 그저께부터 문제를 파악하고 원인을 찾았으며,  #77 을 통해 추가할만한 사항을 추가하였습니다.
- useMemo를 활용하지 않아도 추가적인 리렌더링이 발생하지 않았으므로, 불필요하다 판단하여 관련 부분은 추가하지 않았습니다. 
- 리렌더링 발생 원인은 부모 컴포넌트 내에 선언된 자식 컴포넌트의 변형에 따라, 부모 컴포넌트 리렌더링에 따른 자식 컴포넌트 초기화에서 발생하는 현상이었기 때문입니다. 따라서, useMemo의 기능은 필요하지 않으며, const로 고정하는 것 또한 유효할 것이라 판단됩니다.

- 실수로 기존에 사용하던 컴포넌트 명을 좀 더 포괄적으로 변환해야 할 것 같은데, 충돌이 일어날 것을 염려하여 현재단계에서는 따로 바꾸지는 않았습니다. 일단 완성된 이후 추가적으로 이 부분에 대해 리마인드 해주시면 좋을 것 같네요.

## 🖼️ 스크린샷

### Profiler를 통해 textarea를 변형해도 리렌더링이 감지되지 않는 모습입니다.
<img width="1140" alt="스크린샷 2024-06-12 오후 2 22 29" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/261edc6b-9043-42ad-9f40-140b6092211d">


## 🚨 관련 이슈

- #80
- #77 
- #25 
