### PR TITLE
[PFTF-84] Dropdown 컴포넌트에 누락된 onClick관련 기능 추가

### DIFF
--- a/components/common/Dropdown.tsx
+++ b/components/common/Dropdown.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode } from "react";
 interface Option {
   label: string;
   value: string;
+  onClick?: () => void;
 }
 
 interface DropdownProps {
@@ -10,6 +11,7 @@ interface DropdownProps {
   defaultLabel: ReactNode;
   dropdownOpen: boolean;
   setDropdownOpen: (isOpen: boolean) => void;
+  originPositionRight: boolean;
 }
 
 const Dropdown = ({
@@ -17,19 +19,26 @@ const Dropdown = ({
   defaultLabel,
   dropdownOpen,
   setDropdownOpen,
+  originPositionRight = false,
 }: DropdownProps) => {
   return (
-    <div className="relative">
-      <div className="cursor-pointer">
-        {defaultLabel}
-      </div>
+    <div className="relative z-[1]">
+      <div className="cursor-pointer">{defaultLabel}</div>
       {dropdownOpen && (
-        <div className="absolute top-full mt-2 w-[160px] bg-white border rounded shadow-lg">
+        <div
+          className={`absolute top-full mt-2 w-[160px] rounded border bg-white shadow-lg
+                        ${originPositionRight ? "right-0" : "left-0"}`}
+        >
           {Options.map((option) => (
             <button
               key={option.value}
-              className="flex items-center justify-center border px-4 py-3 hover:bg-gray-100 text-black"
-              onClick={() => setDropdownOpen(false)}
+              className="flex w-full items-center justify-center border px-4 py-3 text-black hover:bg-gray-100"
+              onClick={() => {
+                if (option.onClick !== undefined) {
+                  option.onClick();
+                }
+                setDropdownOpen(false);
+              }}
             >
               {option.label}
             </button>


### PR DESCRIPTION
## 🚀 작업 내용

- Dropdown 컴포넌트의 Option Prop에 onClick을 추가할 수 있게 하여, 드롭다운 선택시의 동작을 시행할 수 있게 하였습니다.
- 추가적으로 드롭다운 내용이 적을 경우의 스타일 에러를 조금 수정했습니다.
- 추가적으로 dropdownOriginPosition을 prop으로 조정할 수 있게 하였습니다.
  - originPositionRight의 boolean을 받아 드롭다운 기준을 조정합니다.

## 📝 참고 사항

- 다른 분과의 충돌을 고려허여 onClick을 선택형 인자로 잡아두었습니다.

## 🖼️ 스크린샷

### Option.onClick이 존재할 경우, 해당 onClick을 실행할 수 있게 했습니다.
<img width="864" alt="스크린샷 2024-06-12 오후 5 44 51" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/02e4e4a5-50c1-44fd-af06-e163ae0b05ab">

## 🚨 관련 이슈

- #84 
- #39 