### PR TITLE
[PFTF-34] 내정보 페이지 헤더(프로필,닉네임) 업데이트 로직 추가

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -6,7 +6,7 @@ export const authConfig = {
     signIn: "/signin",
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         return {
           ...user,
@@ -16,6 +16,10 @@ export const authConfig = {
           accessTokenExpires: user.accessTokenExpires,
           refreshTokenExpires: user.refreshTokenExpires,
         };
+      }
+      if (trigger === "update" && session.user.nickname) {
+        token.nickname = session.user.nickname;
+        token.profileImageUrl = session.user.profileImageUrl;
       }
       if (
         token?.refreshTokenExpires &&

--- a/components/my-page/MyInfo.tsx
+++ b/components/my-page/MyInfo.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import {
-  validateEmail,
-  validateNickname,
-  validatePassword,
-} from "@/util/validation";
+import { validateNickname, validatePassword } from "@/util/validation";
 import Button from "../common/Button";
 import Input from "../common/Input";
 import { useFormValidation } from "@/hooks/useFormValidation";
@@ -13,6 +9,8 @@ import { patchUser } from "@/util/api";
 import useToggle from "@/hooks/useToggle";
 import NotificationPopup from "../common/Popup/NotificationPopup";
 import ProfileImageUploader from "./ProfileImageUploader";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 
 interface Props {
   email: string;
@@ -23,6 +21,8 @@ interface Props {
 }
 
 const MyInfo = ({ data }: { data: Props }) => {
+  const { update } = useSession();
+  const router = useRouter();
   const initialState = {
     email: data.email,
     nickName: data.nickname,
@@ -72,6 +72,13 @@ const MyInfo = ({ data }: { data: Props }) => {
 
     try {
       await patchUser(body);
+      await update({
+        user: {
+          nickname: state.nickName,
+          profileImageUrl: selectedImage || null,
+        },
+      });
+      router.refresh();
       setPopupMessage("정보가 성공적으로 업데이트되었습니다.");
       setState({ ...state, password: "", confirmPassword: "" });
     } catch (error: any) {


### PR DESCRIPTION
## 🚀 작업 내용

- [x]  내정보 페이지 헤더(프로필,닉네임) 업데이트 로직 추가

## 📝 참고 사항

- update를 트리거하는 trigger 속성을 auth.config에 추가
- 내정보 업데이트시 refresh를 통한 업데이트 

## 🖼️ 스크린샷

![Jun-21-2024 20-08-04](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/100824183/907d13f2-466f-4bb9-8a5e-808014eb9f97)


## 🚨 관련 이슈

-
