### PR TITLE
[PFTF-37] 예약 내역 페이지 작업

### DIFF
--- a/app/(app)/reservations/page.tsx
+++ b/app/(app)/reservations/page.tsx
@@ -1,9 +1,154 @@
-import React from "react";
+"use client";
+import React, { useEffect, useState, useCallback } from "react";
+import FilterDropdown from "@/components/common/FilterDropdown";
+import ReservationCanvanCard from "@/components/reservation/ReservationCanvanCard";
+import Image from "next/image";
+import { useInView } from "react-intersection-observer";
+import { getMyReservations } from "@/util/api"; // 내 예약 리스트 조회 API 함수 가져오기
 
-type Props = {};
+interface Activity {
+  bannerImageUrl: string;
+  title: string;
+  id: number;
+}
 
-const page = (props: Props) => {
-  return <div>page</div>;
+interface Reservation {
+  id: number;
+  teamId: string;
+  userId: number;
+  activity: Activity;
+  scheduleId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiResponse {
+  cursorId: number;
+  reservations: Reservation[];
+  totalCount: number;
+}
+
+const Home = () => {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [filter, setFilter] = useState<string>("all");
+  const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [cursorId, setCursorId] = useState<number>(0);
+  const { ref, inView } = useInView();
+
+  const getReservations = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const query = { cursorId, size: 10 }; // 필요한 쿼리 파라미터 설정
+      const data: ApiResponse = await getMyReservations(query);
+      setReservations((prev) => [...prev, ...data.reservations]);
+      setCursorId(data.cursorId);
+    } catch (error) {
+      console.error("Error fetching reservations:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, cursorId]);
+
+  useEffect(() => {
+    getReservations();
+  }, [getReservations]);
+
+  useEffect(() => {
+    if (inView) {
+      getReservations();
+    }
+  }, [inView, getReservations]);
+
+  const getStatusText = (status: string, endTime: string) => {
+    const now = new Date();
+    const end = new Date(endTime);
+
+    if (status === "confirmed" && now > end) {
+      return "체험 완료";
+    }
+
+    switch (status) {
+      case "pending":
+        return "예약 신청";
+      case "canceled":
+        return "예약 취소";
+      case "confirmed":
+        return "예약 승인";
+      case "declined":
+        return "예약 거절";
+      case "completed":
+        return "체험 완료";
+      default:
+        return "";
+    }
+  };
+
+  const handleFilterChange = (filterType: string) => {
+    setFilter(filterType);
+    setDropdownOpen(false);
+  };
+
+  const filteredReservations = reservations.filter((reservation) => {
+    if (filter === "all") return true;
+    if (filter === "completed") return reservation.status === "completed";
+    return reservation.status === filter;
+  });
+
+  const filterOptions = [
+    { label: "전체 보기", value: "all" },
+    { label: "예약 신청", value: "pending" },
+    { label: "예약 취소", value: "canceled" },
+    { label: "예약 승인", value: "confirmed" },
+    { label: "예약 거절", value: "declined" },
+    { label: "체험 완료", value: "completed" },
+  ];
+
+  return (
+    <div className="min-h-screen py-4" style={{ padding: "30px 15%" }}>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-3xl font-bold">예약 내역</h1>
+        <FilterDropdown
+          filterOptions={filterOptions}
+          selectedFilter={filter}
+          onFilterChange={handleFilterChange}
+          dropdownOpen={dropdownOpen}
+          setDropdownOpen={setDropdownOpen}
+        />
+      </div>
+      {filteredReservations.length > 0 ? (
+        filteredReservations.map((reservation, index) => (
+          <ReservationCanvanCard
+            key={index}
+            reservation={reservation}
+            getStatusText={getStatusText}
+          />
+        ))
+      ) : (
+        <div className="mx-auto mt-20 flex w-fit flex-col items-center">
+          <Image
+            src="/icons/no-result.svg"
+            width={130}
+            height={177}
+            alt="아직 등록된 예약이 없습니다."
+          />
+          <span className="mt-10 inline-block text-xl font-medium text-gray-70 md:text-2xl">
+            아직 등록된 예약이 없어요.
+          </span>
+        </div>
+      )}
+      <div ref={ref} className="h-1"></div>
+      {loading && <div className="text-center">로딩 중...</div>}
+    </div>
+  );
 };
 
-export default page;
+export default Home;

--- a/components/common/Dropdown.tsx
+++ b/components/common/Dropdown.tsx
@@ -29,7 +29,7 @@ const Dropdown = ({
         {defaultLabel && <div className="cursor-pointer">{defaultLabel}</div>}
         {dropdownOpen && (
           <div
-            className={`absolute top-full mt-2 rounded border bg-white shadow-lg 
+            className={`absolute z-10 top-full mt-2 rounded border bg-white shadow-lg 
                         ${customClassName ? customClassName : originPositionRight ? "right-0" : "left-0"}`}
           >
             {Options.map((option) => (

--- a/components/common/FilterDropdown.tsx
+++ b/components/common/FilterDropdown.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 import Dropdown from "./Dropdown";
- 
 
 interface FilterOption {
   label: string;
@@ -24,25 +23,41 @@ const FilterDropdown = ({
 }: FilterDropdownProps) => {
   const selectedOptionLabel =
     filterOptions.find((option) => option.value === selectedFilter)?.label ||
-    "전체";
+    "전체 보기";
+
+  const handleOptionClick = (value: string) => {
+    onFilterChange(value);
+  };
+
+  const optionsWithOnClick = filterOptions.map((option) => ({
+    ...option,
+    onClick: () => handleOptionClick(option.value),
+  }));
+
   return (
     <Dropdown
-      Options={filterOptions}
-      defaultLabel={<button
-        className="bg-white w-[40px] h-[40px] md:w-[160px] md:h-[53px] p-2 rounded-lg border border-emerald-800"
-        onClick={() => setDropdownOpen(!dropdownOpen)}
-      >
-        <div className="flex items-center px-2 md:justify-between">
-          <p className="hidden text-emerald-800 font-bold md:block">
-            {selectedOptionLabel}
-          </p>
-          <div
-            className={`bg-[url('/icons/chevron_down.svg')] bg-center bg-no-repeat ${dropdownOpen ? "rotate-180" : "rotate-0"}`}
-          ></div>
-        </div>
-      </button>}
+      Options={optionsWithOnClick}
+      defaultLabel={
+        <button
+          className="bg-white w-[40px] h-[40px] md:w-[160px] md:h-[53px] p-2 rounded-lg border border-emerald-800"
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+        >
+          <div className="flex items-center px-2 md:justify-between">
+            <p className="hidden text-emerald-800 font-bold md:block">
+              {selectedOptionLabel}
+            </p>
+            <div
+              className={`bg-[url('/icons/chevron_down.svg')] bg-center bg-no-repeat ${
+                dropdownOpen ? "rotate-180" : "rotate-0"
+              }`}
+            ></div>
+          </div>
+        </button>
+      }
       dropdownOpen={dropdownOpen}
-      setDropdownOpen={setDropdownOpen} originPositionRight={false}    />
+      setDropdownOpen={setDropdownOpen}
+      originPositionRight={false}
+    />
   );
 };
 

--- a/components/common/FilterDropdown.tsx
+++ b/components/common/FilterDropdown.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Dropdown from "./Dropdown";
+import DropdownArrow from "./svg/DropdownArrowSvg";
 
 interface FilterOption {
   label: string;
@@ -42,15 +43,15 @@ const FilterDropdown = ({
           className="bg-white w-[40px] h-[40px] md:w-[160px] md:h-[53px] p-2 rounded-lg border border-emerald-800"
           onClick={() => setDropdownOpen(!dropdownOpen)}
         >
-          <div className="flex items-center px-2 md:justify-between">
+          <div className="flex items-center justify-center md:justify-between px-2">
             <p className="hidden text-emerald-800 font-bold md:block">
               {selectedOptionLabel}
             </p>
             <div
-              className={`bg-[url('/icons/chevron_down.svg')] bg-center bg-no-repeat ${
-                dropdownOpen ? "rotate-180" : "rotate-0"
-              }`}
-            ></div>
+              className={`flex h-6 w-6 items-center justify-center duration-100 md:h-5 md:w-5 ${dropdownOpen ? "rotate-180" : "rotate-0"}`}
+            >
+              <DropdownArrow />
+            </div>
           </div>
         </button>
       }

--- a/components/common/FilterDropdown.tsx
+++ b/components/common/FilterDropdown.tsx
@@ -40,15 +40,15 @@ const FilterDropdown = ({
       Options={optionsWithOnClick}
       defaultLabel={
         <button
-          className="bg-white w-[40px] h-[40px] md:w-[160px] md:h-[53px] p-2 rounded-lg border border-emerald-800"
+          className="bg-white w-[100px] h-[40px] md:w-[120px] md:h-[45px] p-2 rounded-lg border border-nomad-black"
           onClick={() => setDropdownOpen(!dropdownOpen)}
         >
           <div className="flex items-center justify-center md:justify-between px-2">
-            <p className="hidden text-emerald-800 font-bold md:block">
+            <p className="text-nomad-black font-bold text-sm md:text-base">
               {selectedOptionLabel}
             </p>
             <div
-              className={`flex h-6 w-6 items-center justify-center duration-100 md:h-5 md:w-5 ${dropdownOpen ? "rotate-180" : "rotate-0"}`}
+              className={`hidden md:flex h-6 w-6 items-center justify-center duration-100 md:h-5 md:w-5 ${dropdownOpen ? "rotate-180" : "rotate-0"}`}
             >
               <DropdownArrow />
             </div>

--- a/components/reservation/ReservationCanvanCard.tsx
+++ b/components/reservation/ReservationCanvanCard.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import Image from "next/image";
+import ReviewModal from "../common/ReviewModal/ReviewModal";
+
+interface Activity {
+  bannerImageUrl: string;
+  title: string;
+  id: number;
+}
+
+interface Reservation {
+  id: number;
+  teamId: string;
+  userId: number;
+  activity: Activity;
+  scheduleId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ReservationCardProps {
+  reservation: Reservation;
+  getStatusText: (status: string, endTime: string) => string;
+}
+
+const ReservationCanvanCard = ({ reservation, getStatusText }: ReservationCardProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  if (!reservation) {
+    return null;
+  }
+
+  const isExperienceCompleted = reservation.status === "completed";
+  
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "pending":
+        return "text-blue-500";
+      case "canceled":
+      case "completed":
+        return "text-gray-500";
+      case "confirmed":
+        return "text-orange-500";
+      case "declined":
+        return "text-red-500";
+      default:
+        return "text-gray-800";
+    }
+  };
+
+  const handleReviewButtonClick = () => {
+    setIsModalOpen(true);
+  };
+
+  return (
+    <div className="relative flex h-32 w-full overflow-visible rounded-3xl bg-white pr-3 shadow-lg outline-[1px] my-4 md:h-52 md:pr-6">
+      <div className="relative mr-2 inline-block h-full w-32 shrink-0 md:mr-6 md:w-52">
+        <Image
+          src={reservation.activity.bannerImageUrl}
+          fill
+          priority
+          className="rounded-l-3xl object-cover"
+          sizes="(max-width: 768px) 135px, (max-width: 1200px) 160px, 204px"
+          alt={reservation.activity.title}
+        />
+      </div>
+      <section className="my-auto inline-block w-full relative">
+        <div className="mb-4 md:mb-6">
+          <span className={`flex items-center font-extrabold text-sm md:text-base ${getStatusColor(reservation.status)}`}>
+            {getStatusText(reservation.status, reservation.endTime)}
+          </span>
+          <h4 className="max-w-[170px] truncate text-nowrap text-sm font-bold leading-[1.625rem] text-green-20 md:max-w-[472px] md:text-xl">
+            {reservation.activity.title}
+          </h4>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-gray-600 text-xs mb-2 md:mb-4 md:text-medium">
+              {reservation.date} · {reservation.startTime} - {reservation.endTime} · {reservation.headCount}명
+            </div>
+            <div className="text-gray-800 font-bold">
+              ₩{reservation.totalPrice.toLocaleString()}
+            </div>
+          </div>
+          {isExperienceCompleted && (
+            <button 
+              className="absolute bottom-1 right-4 bg-nomad-black text-xs text-white py-1 px-2 rounded-lg md:py-2 md:px-4 md:text-medium md:bottom-[-6px]"
+              onClick={handleReviewButtonClick}
+            >
+              후기 작성
+            </button>
+          )}
+        </div>
+      </section>
+      {isModalOpen && (
+        <ReviewModal 
+          reservation={reservation} 
+          setState={setIsModalOpen} 
+        />
+      )}
+    </div>
+  );
+};
+
+export default ReservationCanvanCard;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 내가 예약한 목록이 무한 스크롤로 정렬됩니다.
- [x] 우측 상단의 필터 드롭다운을 통해서 원하는 카드를 선택적으로 볼 수 있습니다.
- [x] '후기 작성' 버튼을 통해서 후기 작성 모달로 들어가 후기를 작성할 수 있습니다.
- [x] '아무것도 없으면 빈 페이지가 뜹니다.
- [x] 반응형을 통해서, 모바일부터 Pc 까지 문제 없이 디자인되어 있습니다.
- [x] API를 통해 데이터를 가져와서 전달합니다.

## 📝 참고 사항

- 우측 상단의 드롭다운을 통해서 reservation.status를 필터링해 원하는 정보를 확인 가능합니다. (전체 포함)
- 구현된 로딩 화면과 빈 페이지를 동일한 방식으로 로딩, 출력합니다.
- 체험 완료 된 정보를 모달로 전달합니다.
- 반응형 UI 및 기능 또한 모두 문제 없습니다.

## 🖼️ 스크린샷
https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/90249043/7a4a85d0-f037-4a87-8bf7-dd0ea1b4c258
### 아무것도 없을 때,
![예약](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/90249043/1c0cf03c-2bbd-4f50-bd03-c790889e7f42)



## 🚨 관련 이슈

- #37 
- #22 
- #39 
- #42 

![image](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/90249043/7d857de9-9e3f-40ec-9199-32b5328cb0cd)

빌드 관련 문제 없습니다! deploy 부탁드립니다!
![디자인 1](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/90249043/6c21b469-307c-4124-8281-14a36f24a31a)
![디자인 2](https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/90249043/6ac79ff2-242f-4242-bcaf-3a2554919403)

디자인 부분 개선 완료했습니다. 다른 방식의 디자인이 필요하다고 생각될시 조사 후 다시 변경하겠습니다!

