### PR TITLE
체험 상세 / 예약 현황 페이지 버그 픽스 및 기능 추가

### DIFF
--- a/app/(app)/reservation-status/page.tsx
+++ b/app/(app)/reservation-status/page.tsx
@@ -30,7 +30,7 @@ const page = async () => {
   return (
     <div className="min-w-screen mt-1 min-h-screen bg-gray-10 px-4 pb-20 pt-14 md:mt-0 md:px-8 md:pt-16">
       <main className="mx-auto w-full max-w-[75rem]">
-        <header className="max-w-[768px]md:px-4 mx-auto">
+        <header className="mx-auto max-w-[768px] md:px-4">
           <h2 className="mx-auto mb-8 text-[2rem] font-bold leading-normal text-black md:mt-5">
             예약 현황
           </h2>

--- a/app/(app)/reservation-status/page.tsx
+++ b/app/(app)/reservation-status/page.tsx
@@ -30,7 +30,7 @@ const page = async () => {
   return (
     <div className="min-w-screen mt-1 min-h-screen bg-gray-10 px-4 pb-20 pt-14 md:mt-0 md:px-8 md:pt-16">
       <main className="mx-auto w-full max-w-[75rem]">
-        <header className="mx-auto max-w-[768px] md:px-4">
+        <header className="mx-auto max-w-[768px] xl:px-4">
           <h2 className="mx-auto mb-8 text-[2rem] font-bold leading-normal text-black md:mt-5">
             예약 현황
           </h2>

--- a/components/activity-detail/ReservationModal/ReservationDate/ReservationDate.tsx
+++ b/components/activity-detail/ReservationModal/ReservationDate/ReservationDate.tsx
@@ -6,6 +6,7 @@ import DropdownInput from "@/components/common/DropdownInput";
 
 interface ReservationDateType {
   setDate: (date: CalendarValue) => void;
+  time: [string, string] | null;
   setTime: (time: string) => void;
   schedules: {
     id: number;
@@ -17,6 +18,7 @@ interface ReservationDateType {
 
 const ReservationDate = ({
   setDate,
+  time,
   setTime,
   schedules,
 }: ReservationDateType) => {
@@ -46,6 +48,7 @@ const ReservationDate = ({
           예약 가능한 시간
         </span>
         <DropdownInput
+          defaultValue={time !== null ? time[0] + " ~ " + time[1] : null}
           dataArray={schedules.map(
             (item) => item.startTime + " ~ " + item.endTime,
           )}

--- a/components/activity-detail/ReservationModal/ReservationDate/ReservationDatePresenter.tsx
+++ b/components/activity-detail/ReservationModal/ReservationDate/ReservationDatePresenter.tsx
@@ -40,6 +40,7 @@ const ReservationDatePresenter = ({
       </h5>
       <div className="hidden xl:block">
         <ReservationDate
+          time={time}
           setDate={setDate}
           setTime={setTime}
           schedules={schedules}
@@ -70,6 +71,7 @@ const ReservationDatePresenter = ({
           }}
         >
           <ReservationDate
+            time={time}
             setDate={setDate}
             setTime={setTime}
             schedules={schedules}

--- a/components/activity-detail/ReservationModal/index.tsx
+++ b/components/activity-detail/ReservationModal/index.tsx
@@ -84,26 +84,23 @@ const ReservationModal = ({
       return;
     }
 
-    try {
-      const response = await postActivityReservation(Number(activityId), {
-        scheduleId: selectedSchedule.current.id,
-        headCount: currentReservationCount,
-      });
-      if (typeof response === "string") {
-        throw new Error(response);
-      }
-      setNotificationMessage("예약 신청이 성공했어요!");
-      setIsNotificationOpen(true);
-    } catch (err: any) {
-      if (err === "Unauthorized") {
+    const response = await postActivityReservation(Number(activityId), {
+      scheduleId: selectedSchedule.current.id,
+      headCount: currentReservationCount,
+    });
+    if (typeof response === "string") {
+      if (response === "Unauthorized") {
         setNotificationMessage("로그인을 먼저 해주세요!");
         setIsNotificationOpen(true);
         return;
       }
 
-      setNotificationMessage(err);
+      setNotificationMessage(response);
       setIsNotificationOpen(true);
+      return;
     }
+    setNotificationMessage("예약 신청이 성공했어요!");
+    setIsNotificationOpen(true);
   };
 
   const handlePopupClose = () => {

--- a/components/activity-detail/ReservationModal/index.tsx
+++ b/components/activity-detail/ReservationModal/index.tsx
@@ -42,23 +42,6 @@ const ReservationModal = ({
 
   const router = useRouter();
 
-  // calendar에서 날짜가 선택되었을 때 실행하는 함수
-  const handleSelectDay = (item: CalendarValue) => {
-    if (item !== null) {
-      const selectedDate = item.toLocaleString().split(". ");
-      const month =
-        selectedDate[1].length === 2 ? selectedDate[1] : "0" + selectedDate[1];
-      const day =
-        selectedDate[2].length === 2 ? selectedDate[2] : "0" + selectedDate[2];
-      const date = selectedDate[0] + "-" + month + "-" + day;
-
-      setReservationDate(date);
-      setFilteredSchedule(schedules.filter((item) => item.date === date));
-      setReservationTime(null);
-      selectedSchedule.current = null;
-    }
-  };
-
   // 예약할 일정을 선택했을 경우 실행할 함수
   const handleDropdownSelect = (selectedTime: string) => {
     if (selectedTime !== null) {
@@ -71,6 +54,35 @@ const ReservationModal = ({
         selectedSchedule.current.startTime,
         selectedSchedule.current.endTime,
       ]);
+    }
+  };
+
+  // calendar에서 날짜가 선택되었을 때 실행하는 함수
+  const handleSelectDay = (item: CalendarValue) => {
+    if (item !== null) {
+      const selectedDate = item.toLocaleString().split(". ");
+      const month =
+        selectedDate[1].length === 2 ? selectedDate[1] : "0" + selectedDate[1];
+      const day =
+        selectedDate[2].length === 2 ? selectedDate[2] : "0" + selectedDate[2];
+      const date = selectedDate[0] + "-" + month + "-" + day;
+      const filteredSchedules = schedules.filter((item) => item.date === date);
+
+      setReservationDate(date);
+      setFilteredSchedule(filteredSchedules);
+      if (filteredSchedules.length !== 0) {
+        selectedSchedule.current = filteredSchedules[0];
+        console.log(filteredSchedules[0]);
+        setReservationTime([
+          filteredSchedules[0].startTime,
+          filteredSchedules[0].endTime,
+        ]);
+
+        return;
+      }
+
+      setReservationTime(null);
+      selectedSchedule.current = null;
     }
   };
 

--- a/components/activity-detail/ReservationModal/index.tsx
+++ b/components/activity-detail/ReservationModal/index.tsx
@@ -89,16 +89,19 @@ const ReservationModal = ({
         scheduleId: selectedSchedule.current.id,
         headCount: currentReservationCount,
       });
+      if (typeof response === "string") {
+        throw new Error(response);
+      }
       setNotificationMessage("예약 신청이 성공했어요!");
       setIsNotificationOpen(true);
     } catch (err: any) {
-      if (err.message === "Unauthorized") {
+      if (err === "Unauthorized") {
         setNotificationMessage("로그인을 먼저 해주세요!");
         setIsNotificationOpen(true);
         return;
       }
 
-      setNotificationMessage(err.message);
+      setNotificationMessage(err);
       setIsNotificationOpen(true);
     }
   };

--- a/components/activity-detail/ReservationModal/index.tsx
+++ b/components/activity-detail/ReservationModal/index.tsx
@@ -105,6 +105,12 @@ const ReservationModal = ({
 
   const handlePopupClose = () => {
     setIsNotificationOpen(false);
+    if (notificationMessage === "예약 신청이 성공했어요!") {
+      router.refresh();
+      setTimeout(() => {
+        router.push("/reservations");
+      }, 500);
+    }
   };
 
   return (

--- a/components/reservation-status/ReservationCalendar.tsx
+++ b/components/reservation-status/ReservationCalendar.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import useCalendar from "./useCalendar";
 import { subMonths } from "date-fns";
-import { getMyActivityReservationDashBoard } from "@/util/api";
+import { getActivityById, getMyActivityReservationDashBoard } from "@/util/api";
 import StatusChipList from "./StatusChipList";
 import ModalPortal from "../common/ModalPortal";
 import { ReservationsStatus } from "@/util/apiType";
@@ -79,9 +79,28 @@ const ReservationCalendar = ({
     setIsModalOpen(true);
   };
 
+  const handleInitializeAtFirstReservation = async () => {
+    const response = await getActivityById(selectedActivityId);
+    const reservations = response.schedules.filter(
+      (item: any) => new Date(item.date) > calendar.currentDate,
+    );
+    if (reservations.length !== 0) {
+      const moveToYear =
+        new Date(reservations[0].date).getFullYear() -
+        calendar.currentDate.getFullYear();
+      const moveToMonth =
+        new Date(reservations[0].date).getMonth() -
+        calendar.currentDate.getMonth();
+      const moveStep = moveToYear * 12 + moveToMonth;
+      handleClickMonthChangeButton(moveStep);
+      return;
+    }
+    handleClickMonthChangeButton(0);
+  };
+
   useEffect(() => {
     if (initialized.current === false) {
-      handleClickMonthChangeButton(0);
+      handleInitializeAtFirstReservation();
       initialized.current = true;
     } else {
       handleCalendarRefresh(0);

--- a/components/reservation-status/ReservationCalendar.tsx
+++ b/components/reservation-status/ReservationCalendar.tsx
@@ -137,7 +137,7 @@ const ReservationCalendar = ({
                     reservationInfo={
                       reservationStatusOfMonth[dayItem].reservations
                     }
-                    date={dayItem}
+                    date={currentMonth.current + dayItem}
                     onChipClick={(type) => {
                       handleChipSelect(type);
                       setSelectedDay(dayItem);

--- a/components/reservation-status/ReservationStatus.tsx
+++ b/components/reservation-status/ReservationStatus.tsx
@@ -43,7 +43,7 @@ const ReservationStatus = ({
 
   return (
     <div className="w-full">
-      {renderDropdown()}
+      <div className="mx-auto max-w-[768px]">{renderDropdown()}</div>
       {selectedActivity !== null ? (
         <ReservationCalendar selectedActivityId={selectedActivity} />
       ) : (

--- a/components/reservation-status/StatusChipList.tsx
+++ b/components/reservation-status/StatusChipList.tsx
@@ -7,7 +7,7 @@ interface StatusChipProps {
     confirmed: number;
     pending: number;
   };
-  date: number;
+  date: string;
   onChipClick: (chipType: "pending" | "confirmed") => void;
 }
 
@@ -16,7 +16,10 @@ const StatusChipList = ({
   date,
   onChipClick,
 }: StatusChipProps) => {
-  const isPassedDate = date < new Date().getDate();
+  const today = new Date();
+  const selectedDate = new Date(date);
+
+  let isPassedDate = today > selectedDate ? true : false;
 
   return (
     <div className="flex flex-col gap-0.5 xl:gap-1">


### PR DESCRIPTION
## 🚀 작업 내용

### 예약 현황 페이지
- 예약 현황 헤더의 스타일이 제대로 적용되지 않던 문제 해결
- 예약 현황에서 지나지 않은 날짜가 만료 처리가 되던 문제 해결
- 예약 현황에서 이후 날짜의 가장 빠른 예약 일정이 있는 날이 있는 달로 이동하도록 함

### 체험 상세 페이지
- 예약 완료 이후 예약 내역 페이지로 이동하도록 힘
- 예약을 하기 위해 달력을 선택할 경우 가장 빠른 예약 일정을 자동으로 선택하도록 함.
- 예약 실패시에 대한 에러 처리가 잘 되지 않던 문제 해결

## 📝 참고 사항


## 🖼️ 스크린샷

### 예약 현황에서 체험 선택시 자동으로 현재 일자에서 가장 빠른 일정이 있는 달로 이동하도록 합니다.
https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/6e0f8951-df26-4db1-802f-c23bceb62f78

### 체험 상세에서 예약하고자 하는 일자를 선택할 때 등록된 예약 일정이 있다면 해당 일정을 자동으로 선택합니다.
https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/f8e90f98-1860-4faa-ba18-fe0f7537ef3c


![image](이미지url)

## 🚨 관련 이슈

-
