### PR TITLE
메인 페이지에 line-clamp, Tooltip 수정 후 재적용

### DIFF
--- a/components/common/CardResource.tsx
+++ b/components/common/CardResource.tsx
@@ -26,7 +26,7 @@ export const CardResourcePopular = ({ item }: CardProps) => {
             {item.rating} ({item.reviewCount})
           </span>
         </div>
-        <div className="line-clamp-2 h-[55px] w-[146px] break-keep text-[18px] font-[700] md:h-[90px] md:w-[230px] md:text-[30px]">
+        <div className="break-word line-clamp-2 h-[55px] w-[146px] text-[18px] font-[700] md:h-[90px] md:w-[230px] md:text-[30px]">
           {item.title}
         </div>
         <div className="flex gap-[5px] text-[16px] font-[700] md:text-[20px]">

--- a/components/common/CardResource.tsx
+++ b/components/common/CardResource.tsx
@@ -61,7 +61,9 @@ export const CardResourceCategory = ({ item }: CardProps) => {
           </span>
         </div>
         <div className="truncate break-keep pb-[5px] text-[18px] font-[600] md:text-[24px]">
-          {item.title}
+          <Tooltip content={item.title} color="foreground">
+            {item.title}
+          </Tooltip>
         </div>
         <div className="flex gap-[5px] text-[20px] font-[700] md:text-[28px]">
           <span>₩ {item.price.toLocaleString()}</span>

--- a/components/common/CardResource.tsx
+++ b/components/common/CardResource.tsx
@@ -26,7 +26,7 @@ export const CardResourcePopular = ({ item }: CardProps) => {
             {item.rating} ({item.reviewCount})
           </span>
         </div>
-        <div className="break-word line-clamp-2 h-[55px] w-[146px] text-[18px] font-[700] md:h-[90px] md:w-[230px] md:text-[30px]">
+        <div className="break-word line-clamp-2 h-[55px] w-[146px] break-all text-[18px] font-[700] md:h-[90px] md:w-[230px] md:text-[30px]">
           {item.title}
         </div>
         <div className="flex gap-[5px] text-[16px] font-[700] md:text-[20px]">
@@ -61,8 +61,12 @@ export const CardResourceCategory = ({ item }: CardProps) => {
           </span>
         </div>
         <div className="truncate break-keep pb-[5px] text-[18px] font-[600] md:text-[24px]">
-          <Tooltip content={item.title} color="foreground">
-            {item.title}
+          <Tooltip
+            content={item.title}
+            color="foreground"
+            placement="top-start"
+          >
+            <span>{item.title}</span>
           </Tooltip>
         </div>
         <div className="flex gap-[5px] text-[20px] font-[700] md:text-[28px]">


### PR DESCRIPTION
## 🚀 작업 내용

- line-clamp 미적용 부분 수정 후 재 적용
- 긴 타이틀에 Tooltip 적용

## 📝 참고 사항

-

## 🖼️ 스크린샷

![image](이미지url)

## 🚨 관련 이슈

-
