### PR TITLE
체험 상세 페이지 설명 자동 늘임 추가 및 과도한 길이의 제목 스타일 문제 해결

### DIFF
--- a/app/(app)/activity-detail/[activityId]/page.tsx
+++ b/app/(app)/activity-detail/[activityId]/page.tsx
@@ -7,6 +7,7 @@ import ReservationModal from "@/components/activity-detail/ReservationModal";
 import { getActivityById, getActivityReviews, getUser } from "@/util/api";
 import StarSvg from "@/components/common/svg/StarSvg";
 import { auth } from "@/auth";
+import { Tooltip } from "@nextui-org/react";
 
 interface ActivityDetailType {
   id: number;
@@ -44,9 +45,11 @@ const page = async ({ params }: { params: { activityId: string } }) => {
             <span className="mb-2.5 text-sm leading-normal text-black">
               {data.category}
             </span>
-            <h1 className="mb-4 text-2xl font-bold leading-normal text-nomad-black md:text-3xl">
-              {data.title}
-            </h1>
+            <Tooltip content={data.title} color="foreground" placement="bottom">
+              <h1 className="mb-4 max-w-[calc(100vw-15px)] cursor-default overflow-hidden truncate text-2xl font-bold leading-normal text-nomad-black md:text-3xl">
+                {data.title}
+              </h1>
+            </Tooltip>
             <div className="flex items-center gap-3 text-sm text-black">
               <span className="flex items-center gap-1.5">
                 <StarSvg />
@@ -78,8 +81,9 @@ const page = async ({ params }: { params: { activityId: string } }) => {
                 체험 설명
               </h3>
               <textarea
+                rows={data.description.valueOf().split(/\n/).length}
                 disabled
-                className="w-full resize-none text-wrap border-none bg-transparent text-base leading-[162.5%] text-nomad-black"
+                className="max-h-[11.25rem] min-h-20 w-full resize-none text-wrap border-none bg-transparent text-base leading-[162.5%] text-nomad-black"
                 defaultValue={data.description}
               />
               <hr className="mb-10 mt-10" />


### PR DESCRIPTION
## 🚀 작업 내용

- 페이지 설명 자동 늘임 추가 
- 과도한 길이의 제목 스타일 문제 해결

## 📝 참고 사항

-

## 🖼️ 스크린샷

### 제목 길이 버그 수정
<img width="511" alt="스크린샷 2024-06-23 오후 10 26 32" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/7188654e-5c32-4eae-966c-3fdf444ec93b">

### textarea 관련 자동 늘임 설정
<img width="836" alt="스크린샷 2024-06-23 오후 10 28 17" src="https://github.com/soohwan93/codeit-part4-team14-GlobalNomad/assets/155033024/fd908597-94ef-4725-b176-0c8b5c5568cf">


## 🚨 관련 이슈

-
