### PR TITLE
예약 내역 페이지 (버튼 조정 및 픽스) 및 알림 (토글 및 알림 내역) 픽스

### DIFF
--- a/components/common/GNB/auth/AlertMenu.tsx
+++ b/components/common/GNB/auth/AlertMenu.tsx
@@ -25,6 +25,11 @@ const AlertMenu = ({
     e.stopPropagation(); // 이벤트 버블링 막기
     setIsAlertClicked((prev) => !prev);
   };
+
+  const handleCloseModal = () => {
+    setIsAlertClicked(false);
+  };
+
   return (
     <>
       <div onClick={handleAlertClick} className="relative">
@@ -37,6 +42,7 @@ const AlertMenu = ({
             notifications={notifications}
             setNotifications={setNotifications}
             buttonPosition={{ left: 0, top: 22 }}
+            onClose={handleCloseModal} // 추가된 부분
           />
         )}
         <div className="absolute">{isAlertClicked}</div>

--- a/components/common/GNB/auth/AlertMenu.tsx
+++ b/components/common/GNB/auth/AlertMenu.tsx
@@ -13,13 +13,14 @@ interface Props {
 }
 
 const AlertMenu = ({
-  totalCount,
+  totalCount: initialTotalCount,
   cursorId,
   notifications: initialNotifications,
 }: Props) => {
   const [notifications, setNotifications] =
     useState<Notification[]>(initialNotifications);
   const [isAlertClicked, setIsAlertClicked] = useState(false);
+  const [totalCount, setTotalCount] = useState(initialTotalCount); // 알림 카운트를 상태로 관리
 
   const handleAlertClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation(); // 이벤트 버블링 막기
@@ -38,11 +39,12 @@ const AlertMenu = ({
           <NotificationModal
             cursorId={cursorId}
             totalCount={totalCount}
+            setTotalCount={setTotalCount} // setTotalCount를 전달
             setState={setIsAlertClicked}
             notifications={notifications}
             setNotifications={setNotifications}
             buttonPosition={{ left: 0, top: 22 }}
-            onClose={handleCloseModal} // 추가된 부분
+            onClose={handleCloseModal}
           />
         )}
         <div className="absolute">{isAlertClicked}</div>

--- a/components/common/NotificationModal/NotificationModal.tsx
+++ b/components/common/NotificationModal/NotificationModal.tsx
@@ -18,21 +18,23 @@ export interface Notification {
 interface NotificationModalProps {
   cursorId: number | null;
   totalCount: number;
+  setTotalCount: React.Dispatch<React.SetStateAction<number>>; // 추가된 부분
   setState: React.Dispatch<React.SetStateAction<boolean>>;
   notifications: Notification[];
   setNotifications: React.Dispatch<React.SetStateAction<Notification[]>>;
   buttonPosition: { top: number; left: number };
-  onClose: () => void; // 추가된 부분
+  onClose: () => void;
 }
 
 const NotificationModal = ({
   cursorId: initialCursorId,
   totalCount,
+  setTotalCount, // 추가된 부분
   setState,
   notifications,
   setNotifications,
   buttonPosition,
-  onClose, // 추가된 부분
+  onClose,
 }: NotificationModalProps) => {
   const { ref, inView } = useInView();
   const [loading, setLoading] = useState(false);
@@ -104,6 +106,7 @@ const NotificationModal = ({
       setNotifications(
         notifications.filter((notification) => notification.id !== id),
       );
+      setTotalCount((prevCount) => prevCount - 1); // 알림 카운트 업데이트
     } catch (error) {
       console.error("Failed to delete notification", error);
     }
@@ -113,9 +116,10 @@ const NotificationModal = ({
     (event: MouseEvent) => {
       if (
         notificationsRef.current &&
-        !notificationsRef.current.contains(event.target as Node)
+        !notificationsRef.current.contains(event.target as Node) &&
+        !(event.target as Element).closest("#alertSvg")
       ) {
-        onClose(); // 수정된 부분
+        onClose();
       }
     },
     [onClose],

--- a/components/common/NotificationModal/NotificationModal.tsx
+++ b/components/common/NotificationModal/NotificationModal.tsx
@@ -22,6 +22,7 @@ interface NotificationModalProps {
   notifications: Notification[];
   setNotifications: React.Dispatch<React.SetStateAction<Notification[]>>;
   buttonPosition: { top: number; left: number };
+  onClose: () => void; // 추가된 부분
 }
 
 const NotificationModal = ({
@@ -31,6 +32,7 @@ const NotificationModal = ({
   notifications,
   setNotifications,
   buttonPosition,
+  onClose, // 추가된 부분
 }: NotificationModalProps) => {
   const { ref, inView } = useInView();
   const [loading, setLoading] = useState(false);
@@ -43,6 +45,7 @@ const NotificationModal = ({
       : null,
   );
   const [lastDataLength, setLastDataLength] = useState<number>(5);
+
   const handleResize = () => {
     setWindowWidth(window.innerWidth);
   };
@@ -84,8 +87,6 @@ const NotificationModal = ({
       cursorId &&
       lastDataLength === 5
     ) {
-      console.log(totalCount);
-      console.log(cursorId);
       fetchNotifications();
     }
   }, [
@@ -112,13 +113,12 @@ const NotificationModal = ({
     (event: MouseEvent) => {
       if (
         notificationsRef.current &&
-        !notificationsRef.current.contains(event.target as Node) &&
-        !(event.target as Element).closest("#notificationModal")
+        !notificationsRef.current.contains(event.target as Node)
       ) {
-        setState(false);
+        onClose(); // 수정된 부분
       }
     },
-    [setState],
+    [onClose],
   );
 
   useEffect(() => {
@@ -152,86 +152,85 @@ const NotificationModal = ({
   };
 
   return (
-    <>
+    <div
+      ref={notificationsRef}
+      className="fixed z-[50] w-full h-screen bg-[#CED8D5] border border-[#CBC9CF] rounded-[10px] shadow-[0px_2px_8px_0px_rgba(120,116,134,0.25)] md:absolute md:w-[368px] md:max-h-[calc(4*152px+64px)]"
+      style={{
+        top: windowWidth >= 768 ? buttonPosition.top + 10 : 0,
+        left: windowWidth >= 768 ? buttonPosition.left - 170 : buttonPosition.left,
+      }}
+      onClick={(e) => e.stopPropagation()} // 이벤트 버블링 막기
+    >
       <div
-        ref={notificationsRef}
-        className="over fixed z-[50] h-screen w-full rounded-[10px] border border-[#CBC9CF] bg-[#CED8D5] shadow-[0px_2px_8px_0px_rgba(120,116,134,0.25)] md:absolute md:max-h-[calc(4*152px+64px)] md:w-[368px]"
-        style={{
-          top: windowWidth >= 768 ? buttonPosition.top + 10 : 0,
-          left:
-            windowWidth >= 768
-              ? buttonPosition.left - 170
-              : buttonPosition.left,
-        }}
+        id="notificationModal"
+        className="flex items-center justify-between p-6"
       >
-        <div
-          id="notificationModal"
-          className="flex items-center justify-between p-6"
-        >
-          <p className="text-[20px] font-bold leading-normal">
-            {`알림 ${totalCount}개`}
+        <p className="text-[20px] font-bold leading-normal">
+          {`알림 ${totalCount}개`}
+        </p>
+        <button
+          type="button"
+          onClick={onClose} // 모달을 닫음
+          className="h-10 w-10 bg-[url('/icons/btn_X.svg')] bg-cover"
+        ></button>
+      </div>
+      {notifications.length === 0 ? (
+        <div className="flex h-full flex-col items-center justify-center pb-32 text-center">
+          <AlertSvg isClicked={false} />
+          <p className="mt-4 text-[20px] font-bold">
+            새로운 알림이 없습니다.
           </p>
-          <button
-            type="button"
-            onClick={() => setState((prev) => !prev)}
-            className="h-10 w-10 bg-[url('/icons/btn_X.svg')] bg-cover"
-          ></button>
+          <p className="text-[14px] text-[#a4a1aa]">
+            서비스와 다양한 알림을 이곳에서 모아볼 수 있어요.
+          </p>
         </div>
-        {notifications.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center pb-32 text-center">
-            <AlertSvg isClicked={false} />
-            <p className="mt-4 text-[20px] font-bold">
-              새로운 알림이 없습니다.
-            </p>
-            <p className="text-[14px] text-[#a4a1aa]">
-              서비스와 다양한 알림을 이곳에서 모아볼 수 있어요.
-            </p>
-          </div>
-        ) : (
-          <div
-            className="mt-4 flex h-full flex-col items-center gap-2 px-4 md:h-[calc(4*120px+64px)]"
-            style={{ overflowY: "scroll", scrollbarWidth: "none" }}
-          >
-            {notifications.map((notification) => (
-              <div
-                key={notification.id}
-                className="relative min-h-[120px] w-full rounded-lg bg-white px-3 pb-4 pt-2 md:w-[340px]"
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex h-3 items-center justify-center">
-                    <div
-                      className={` mt-1  h-[5px] w-[5px]  rounded-full ${notification.content.includes("승인") ? "bg-[#0085ff]" : "bg-[#ff472e]"}`}
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(notification.id)}
-                    className="h-6 w-6 bg-[url('/icons/btn_X.svg')] bg-cover"
-                  ></button>
+      ) : (
+        <div
+          className="mt-4 flex h-full flex-col items-center gap-2 px-4 md:h-[calc(4*120px+64px)]"
+          style={{ overflowY: "scroll", scrollbarWidth: "none" }}
+        >
+          {notifications.map((notification) => (
+            <div
+              key={notification.id}
+              className="relative min-h-[120px] w-full rounded-lg bg-white px-3 pb-4 pt-2 md:w-[340px]"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex h-3 items-center justify-center">
+                  <div
+                    className={` mt-1  h-[5px] w-[5px]  rounded-full ${notification.content.includes("승인") ? "bg-[#0085ff]" : "bg-[#ff472e]"}`}
+                  />
                 </div>
-                <div className="flex flex-col justify-between">
-                  <p className="mb-1 break-words text-[14px] font-normal leading-[22px]">
-                    {renderContent(notification.content)}
-                  </p>
-                </div>
-                <p className=" absolute bottom-3 left-3 text-[12px] font-normal leading-[16px] text-[#a4a1aa]">
-                  {dateFormat(notification.updatedAt)}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 버블링 막기
+                    handleDelete(notification.id);
+                  }}
+                  className="h-6 w-6 bg-[url('/icons/btn_X.svg')] bg-cover"
+                ></button>
+              </div>
+              <div className="flex flex-col justify-between">
+                <p className="mb-1 break-words text-[14px] font-normal leading-[22px]">
+                  {renderContent(notification.content)}
                 </p>
               </div>
-            ))}
-            <div ref={ref} className="h-[1px]"></div>
-            {loading && (
-              <div className="flex h-32 w-full items-center justify-center space-x-2 dark:invert md:h-[calc(4*120px+64px)]">
-                <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black [animation-delay:-0.3s]"></div>
-                <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black [animation-delay:-0.15s]"></div>
-                <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black"></div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </>
+              <p className=" absolute bottom-3 left-3 text-[12px] font-normal leading-[16px] text-[#a4a1aa]">
+                {dateFormat(notification.updatedAt)}
+              </p>
+            </div>
+          ))}
+          <div ref={ref} className="h-[1px]"></div>
+          {loading && (
+            <div className="flex h-32 w-full items-center justify-center space-x-2 dark:invert md:h-[calc(4*120px+64px)]">
+              <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black [animation-delay:-0.3s]"></div>
+              <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black [animation-delay:-0.15s]"></div>
+              <div className="h-3 w-3 animate-bounce rounded-full bg-nomad-black"></div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 };
-// resolve problem
+
 export default NotificationModal;

--- a/components/reservation/ReservationCanvanCard.tsx
+++ b/components/reservation/ReservationCanvanCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import ReviewModal from "../common/ReviewModal/ReviewModal";
+import { patchMyReservation } from "@/util/api";
 
 interface Activity {
   bannerImageUrl: string;
@@ -35,6 +36,7 @@ const ReservationCanvanCard = ({
   getStatusText,
 }: ReservationCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCanceled, setIsCanceled] = useState(reservation.status === "canceled");
 
   if (!reservation) {
     return null;
@@ -60,6 +62,16 @@ const ReservationCanvanCard = ({
 
   const handleReviewButtonClick = () => {
     setIsModalOpen(true);
+  };
+
+  const handleCancelButtonClick = async () => {
+    try {
+      await patchMyReservation(reservation.id, { status: "canceled" });
+      setIsCanceled(true);
+      window.location.reload(); // 페이지 새로고침
+    } catch (error) {
+      console.error("예약 취소에 실패했습니다:", error);
+    }
   };
 
   return (
@@ -96,13 +108,31 @@ const ReservationCanvanCard = ({
               <span className="text-gray-50">/인</span>
             </div>
           </div>
-          {isExperienceCompleted && (
-            <button
-              className="absolute bottom-1 right-4 rounded-lg bg-nomad-black px-2 py-1 text-xs text-white md:bottom-[-6px] md:px-4 md:py-2 md:text-medium"
-              onClick={handleReviewButtonClick}
-            >
-              후기 작성
-            </button>
+          {isExperienceCompleted ? (
+            reservation.reviewSubmitted ? (
+              <button
+                className="absolute bottom-1 right-4 rounded-lg bg-gray-300 px-2 py-1 text-xs text-white md:bottom-[-6px] md:px-4 md:py-2 md:text-medium"
+                disabled
+              >
+                후기 작성 완료
+              </button>
+            ) : (
+              <button
+                className="absolute bottom-1 right-4 rounded-lg bg-nomad-black px-2 py-1 text-xs text-white md:bottom-[-6px] md:px-4 md:py-2 md:text-medium"
+                onClick={handleReviewButtonClick}
+              >
+                후기 작성
+              </button>
+            )
+          ) : (
+            !isCanceled && reservation.status !== "canceled" && (
+              <button
+                className="absolute bottom-1 right-4 rounded-lg border border-nomad-black bg-white px-2 py-1 text-xs text-nomad-black md:bottom-[-6px] md:px-4 md:py-2 md:text-medium"
+                onClick={handleCancelButtonClick}
+              >
+                예약 취소
+              </button>
+            )
           )}
         </div>
       </section>


### PR DESCRIPTION
## 🚀 작업 내용
- 예약 내역 페이지에서 예약 취소가 가능하게 했습니다
- 예약 내역 페이지의 후기 작성 후 후기 작성 버튼이 비활성화 되게 변경했습니다.
- 알림에서 토글이 가능하게 변경했습니다
- 이제 더이상 모달 안쪽을 클릭해도 모달이 꺼지지 않습니다
- 알림을 정상적으로 받아오고 , 해당 알림을 제거할 시 숫자가 자동으로 변경됩니다.

## 📝 참고 사항

-

## 🖼️ 스크린샷

![image](이미지url)

## 🚨 관련 이슈

-
