### PR TITLE
메인 페이지 인기항목 rating 소수점 한자리로 수정

### DIFF
--- a/components/common/CardResource.tsx
+++ b/components/common/CardResource.tsx
@@ -24,7 +24,7 @@ export const CardResourcePopular = ({ item }: CardProps) => {
         <div className="flex gap-[5px]">
           <StarSvg />
           <span className="text-[14px] font-[600]">
-            {item.rating} ({item.reviewCount})
+            {item.rating.toFixed(1)} ({item.reviewCount})
           </span>
         </div>
         <div className="break-word line-clamp-2 h-[55px] w-[146px] break-all text-[18px] font-[700] md:h-[90px] md:w-[230px] md:text-[30px]">
@@ -59,7 +59,7 @@ export const CardResourceCategory = ({ item }: CardProps) => {
         <div className="flex gap-[5px]">
           <StarSvg />
           <span className="text-[16px] font-[500]">
-            {item.rating}{" "}
+            {item.rating.toFixed(1)}{" "}
             <span className="text-[#a1a1a1]">({item.reviewCount})</span>
           </span>
         </div>


### PR DESCRIPTION
## 🚀 작업 내용

- 메인 페이지 인기항목 rating 소수점 한자리로 수정

## 📝 참고 사항

-

## 🖼️ 스크린샷

![image](이미지url)

## 🚨 관련 이슈

-
